### PR TITLE
Only honor ?API_URL= query parameter in development

### DIFF
--- a/app/services/ApiConfiguration.ts
+++ b/app/services/ApiConfiguration.ts
@@ -17,21 +17,25 @@ const inferBaseApiUrl = (): string => {
     url.searchParams.delete(API_URL_QUERY_PARAMETER)
     window.history.replaceState({}, "", url.toString())
 
-    return apiUrlViaQueryParams
+    // Only honor the query parameter in development; in other environments it
+    // could be used to redirect credentials and API traffic to an attacker host
+    if (getEnvironment() === Environment.Development) {
+      return apiUrlViaQueryParams
+    }
+  }
+
+  const apiUrlViaEnv = import.meta.env.VITE_API_URL
+
+  if (apiUrlViaEnv) {
+    return apiUrlViaEnv
   } else {
-    const apiUrlViaEnv = import.meta.env.VITE_API_URL
+    const environment = getEnvironment()
 
-    if (apiUrlViaEnv) {
-      return apiUrlViaEnv
+    if (environment in API_URL_MAPPINGS) {
+      return `${location.protocol}//${API_URL_MAPPINGS[environment as Environment.Staging | Environment.Production]}`
     } else {
-      const environment = getEnvironment()
-
-      if (environment in API_URL_MAPPINGS) {
-        return `${location.protocol}//${API_URL_MAPPINGS[environment as Environment.Staging | Environment.Production]}`
-      } else {
-        const apiUrl = `${location.protocol}//api.${location.host}`
-        return apiUrl
-      }
+      const apiUrl = `${location.protocol}//api.${location.host}`
+      return apiUrl
     }
   }
 }

--- a/tests/services/ApiConfiguration.test.ts
+++ b/tests/services/ApiConfiguration.test.ts
@@ -7,12 +7,13 @@ describe("ApiConfiguration", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
     vi.resetModules()
   })
 
   describe("inferBaseApiUrl", () => {
-    test("should use API_URL query parameter when present", async () => {
-      // Mock window.location with API_URL query parameter
+    test("should use API_URL query parameter in development environment", async () => {
+      // Mock window.location with API_URL query parameter (example.com is not a known host ⇒ Development)
       const mockUrl = new URL("https://example.com?API_URL=https://custom-api.example.com")
       const mockHistory = { replaceState: vi.fn() }
 
@@ -34,6 +35,28 @@ describe("ApiConfiguration", () => {
       expect(mockHistory.replaceState).toHaveBeenCalled()
     })
 
+    test("should ignore API_URL query parameter on a production host", async () => {
+      const mockUrl = new URL("https://videos.ruchij.com?API_URL=https://evil.example")
+      const mockHistory = { replaceState: vi.fn() }
+
+      vi.stubGlobal("window", {
+        location: {
+          href: mockUrl.href,
+          search: mockUrl.search,
+          protocol: mockUrl.protocol,
+          host: mockUrl.host,
+        },
+        history: mockHistory,
+      })
+
+      vi.resetModules()
+      const { apiConfiguration } = await import("~/services/ApiConfiguration")
+
+      expect(apiConfiguration.baseUrl).toBe("https://api.video.home.ruchij.com")
+      // The parameter is still scrubbed from the URL, but its value is never used
+      expect(mockHistory.replaceState).toHaveBeenCalled()
+    })
+
     test("should use VITE_API_URL environment variable when no query param", async () => {
       // Mock window.location without API_URL query parameter
       const mockUrl = new URL("https://example.com")
@@ -48,17 +71,12 @@ describe("ApiConfiguration", () => {
         history: { replaceState: vi.fn() },
       })
 
-      // Mock import.meta.env
-      vi.stubGlobal("import", {
-        meta: {
-          env: {
-            VITE_API_URL: "https://env-api.example.com",
-          },
-        },
-      })
+      vi.stubEnv("VITE_API_URL", "https://env-api.example.com")
 
       vi.resetModules()
-      // Note: This test may not fully work due to import.meta limitations in testing
+      const { apiConfiguration } = await import("~/services/ApiConfiguration")
+
+      expect(apiConfiguration.baseUrl).toBe("https://env-api.example.com")
     })
 
     test("should use API_URL_MAPPINGS for known hosts", async () => {


### PR DESCRIPTION
The `?API_URL=` query parameter was honored unconditionally, so a crafted link like `https://videos.ruchij.com/sign-in?API_URL=https://evil.example` would silently send login credentials and all API traffic to an attacker host. The parameter is now only used when the environment is Development (it is still scrubbed from the URL in all environments), and the previously assertion-free VITE_API_URL test was fixed with `vi.stubEnv` plus new coverage for the dev/production query-param behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)