### PR TITLE
Treat KV-store decode failures as absence and self-heal

### DIFF
--- a/app/providers/ApplicationConfigurationProvider.tsx
+++ b/app/providers/ApplicationConfigurationProvider.tsx
@@ -40,6 +40,7 @@ export const ApplicationConfigurationProvider: FC<ApplicationConfigurationContex
           appConfig => Promise.resolve(appConfig)
         )
       )
+      .catch(() => localStorageConfigurationService.getDefaultApplicationConfiguration())
       .then(appConfig => setApplicationConfiguration(Some.of(appConfig)))
   }, [])
 

--- a/app/services/kv-store/KeyValueStore.ts
+++ b/app/services/kv-store/KeyValueStore.ts
@@ -1,4 +1,5 @@
-import { Option } from "~/types/Option"
+import { Either } from "~/types/Either"
+import { None, Option, Some } from "~/types/Option"
 
 export interface Encoder<A, B> {
   encode(value: A): B
@@ -35,7 +36,16 @@ export class LocalKeyValueStore<K, V extends {}> implements KeyValueStore<K, V> 
         localStorage.getItem(this.stringKey(key))
       )
 
-    return stringValue.map(this.keySpace.valueCodec.decode)
+    return stringValue.flatMap(value =>
+      Either.fromTry(() => this.keySpace.valueCodec.decode(value))
+        .fold<Option<V>>(
+          () => {
+            localStorage.removeItem(this.stringKey(key))
+            return None.of()
+          },
+          decodedValue => Some.of(decodedValue)
+        )
+    )
   }
 
   put(key: K, value: V): void {

--- a/tests/providers/ApplicationConfigurationProvider.test.tsx
+++ b/tests/providers/ApplicationConfigurationProvider.test.tsx
@@ -116,6 +116,26 @@ describe("ApplicationConfigurationProvider", () => {
     })
   })
 
+  test("should fall back to default config when loading the saved config fails", async () => {
+    mockGetApplicationConfiguration.mockRejectedValue(new Error("corrupted stored configuration"))
+    mockGetDefaultApplicationConfiguration.mockResolvedValue({
+      theme: Theme.Light,
+      safeMode: false,
+    })
+
+    render(
+      <ApplicationConfigurationProvider>
+        <TestConsumer />
+      </ApplicationConfigurationProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("theme")).toHaveTextContent("light")
+      expect(screen.getByTestId("safeMode")).toHaveTextContent("false")
+    })
+    expect(mockGetDefaultApplicationConfiguration).toHaveBeenCalled()
+  })
+
   test("should set data-theme attribute on body", async () => {
     mockGetApplicationConfiguration.mockResolvedValue({
       isEmpty: () => true,

--- a/tests/services/KeyValueStore.test.ts
+++ b/tests/services/KeyValueStore.test.ts
@@ -132,6 +132,15 @@ describe("LocalKeyValueStore", () => {
         value: 99,
       })
     })
+    test("should return None and remove the entry when the stored value is corrupt", () => {
+      localStorageMock.setItem("TestStore-key1", "not-valid-json{{{")
+
+      const result = store.get("key1")
+
+      expect(result).toBeInstanceOf(None)
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith("TestStore-key1")
+      expect(localStorageMock.getItem("TestStore-key1")).toBeNull()
+    })
   })
 
   describe("remove", () => {


### PR DESCRIPTION
A corrupted or schema-drifted localStorage entry made `LocalKeyValueStore.get` throw synchronously, which left the app permanently blank (and broke auth-token reads) until the user manually cleared localStorage. `get` now wraps the codec decode in `Either.fromTry`, returning `None` and removing the corrupted entry, and `ApplicationConfigurationProvider` falls back to the default configuration if the config load rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)