### PR TITLE
Fix open redirect in login redirect handling

### DIFF
--- a/app/pages/unauthenticated/AuthFormHelpers.ts
+++ b/app/pages/unauthenticated/AuthFormHelpers.ts
@@ -1,4 +1,15 @@
 import { type ChangeEvent, type Dispatch, type SetStateAction } from "react"
+import { type Option } from "~/types/Option"
+
+const IN_APP_PATH_PATTERN = /^\/(?!\/)/
+
+/**
+ * Restricts a post-authentication redirect target to in-app paths: a single leading
+ * slash (no absolute URLs like `https://evil.example`, no protocol-relative URLs like
+ * `//evil.example`). Anything else falls back to the home page.
+ */
+export const safeRedirectPath = (redirect: Option<string>): string =>
+  redirect.filter((path) => IN_APP_PATH_PATTERN.test(path)).getOrElse(() => "/")
 
 /**
  * Extracts user-facing error messages from an unknown (typically axios) error.

--- a/app/pages/unauthenticated/login/LoginPage.tsx
+++ b/app/pages/unauthenticated/login/LoginPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router"
 import Helmet from "~/components/helmet/Helmet"
 import { Option } from "~/types/Option"
 import { REDIRECT_QUERY_PARAMETER } from "~/services/authentication/AuthenticationService"
+import { safeRedirectPath } from "~/pages/unauthenticated/AuthFormHelpers"
 
 import styles from "./LoginPage.module.scss"
 
@@ -14,8 +15,7 @@ const LoginPage = () => {
   const onAuthenticate = () => {
     const redirect: Option<string> = Option.fromNullable(searchParams.get(REDIRECT_QUERY_PARAMETER))
 
-    const nextUrl = redirect.getOrElse(() => "/")
-    navigate(nextUrl)
+    navigate(safeRedirectPath(redirect))
   }
 
   return (

--- a/app/pages/useRedirectOnAuth.ts
+++ b/app/pages/useRedirectOnAuth.ts
@@ -30,7 +30,8 @@ export const useRedirectOnAuth = (redirectWhenAuthenticated: boolean): void => {
         }
       })
     } else {
-      const redirectUrl = `/sign-in?${REDIRECT_QUERY_PARAMETER}=${window.location.pathname}`
+      const redirectTarget = encodeURIComponent(window.location.pathname + window.location.search)
+      const redirectUrl = `/sign-in?${REDIRECT_QUERY_PARAMETER}=${redirectTarget}`
 
       maybeToken.fold(
         () => {

--- a/tests/pages/AuthenticatedLayout.test.tsx
+++ b/tests/pages/AuthenticatedLayout.test.tsx
@@ -48,7 +48,7 @@ describe("AuthenticatedLayout", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     Object.defineProperty(window, "location", {
-      value: { pathname: "/videos" },
+      value: { pathname: "/videos", search: "" },
       writable: true,
     })
   })
@@ -101,7 +101,39 @@ describe("AuthenticatedLayout", () => {
     render(<RouterProvider router={router} />)
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=/videos")
+      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=%2Fvideos")
+    })
+  })
+
+  test("should include the encoded query string in the sign-in redirect", async () => {
+    const { getAuthenticationToken } = await import(
+      "~/services/authentication/AuthenticationService"
+    )
+    vi.mocked(getAuthenticationToken).mockReturnValue(None.of())
+    Object.defineProperty(window, "location", {
+      value: { pathname: "/videos", search: "?search-term=cats&page=2" },
+      writable: true,
+    })
+
+    const router = createMemoryRouter([
+      {
+        path: "/",
+        element: <AuthenticatedLayout />,
+        children: [
+          {
+            index: true,
+            element: <div>Child</div>,
+          },
+        ],
+      },
+    ])
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/sign-in?redirect=${encodeURIComponent("/videos?search-term=cats&page=2")}`
+      )
     })
   })
 
@@ -128,7 +160,7 @@ describe("AuthenticatedLayout", () => {
 
     await waitFor(() => {
       expect(removeAuthenticationToken).toHaveBeenCalled()
-      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=/videos")
+      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=%2Fvideos")
     })
   })
 

--- a/tests/pages/LoginPage.test.tsx
+++ b/tests/pages/LoginPage.test.tsx
@@ -5,13 +5,14 @@ import { createMemoryRouter, RouterProvider } from "react-router"
 import React from "react"
 
 const mockNavigate = vi.fn()
+let mockSearchParams = new URLSearchParams()
 
 vi.mock("react-router", async () => {
   const actual = await vi.importActual("react-router")
   return {
     ...actual,
     useNavigate: () => mockNavigate,
-    useSearchParams: () => [new URLSearchParams()],
+    useSearchParams: () => [mockSearchParams],
   }
 })
 
@@ -27,64 +28,64 @@ vi.mock("~/pages/unauthenticated/login/components/login-form/LoginForm", () => (
   ),
 }))
 
+const renderLoginPage = () => {
+  const router = createMemoryRouter([
+    {
+      path: "/",
+      element: <LoginPage />,
+    },
+  ])
+
+  render(<RouterProvider router={router} />)
+}
+
 describe("LoginPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSearchParams = new URLSearchParams()
   })
 
   test("should render login form", () => {
-    const router = createMemoryRouter([
-      {
-        path: "/",
-        element: <LoginPage />,
-      },
-    ])
-
-    render(<RouterProvider router={router} />)
+    renderLoginPage()
 
     expect(screen.getByTestId("login-button")).toBeInTheDocument()
   })
 
   test("should navigate to home on authenticate when no redirect param", () => {
-    const router = createMemoryRouter([
-      {
-        path: "/",
-        element: <LoginPage />,
-      },
-    ])
-
-    render(<RouterProvider router={router} />)
+    renderLoginPage()
 
     fireEvent.click(screen.getByTestId("login-button"))
 
     expect(mockNavigate).toHaveBeenCalledWith("/")
   })
-})
 
-describe("LoginPage with redirect", () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+  test("should navigate to in-app redirect path on authenticate", () => {
+    mockSearchParams = new URLSearchParams("?redirect=/history")
+
+    renderLoginPage()
+
+    fireEvent.click(screen.getByTestId("login-button"))
+
+    expect(mockNavigate).toHaveBeenCalledWith("/history")
   })
 
-  test("should navigate to redirect URL on authenticate", async () => {
-    vi.doMock("react-router", async () => {
-      const actual = await vi.importActual("react-router")
-      return {
-        ...actual,
-        useNavigate: () => mockNavigate,
-        useSearchParams: () => [new URLSearchParams("?redirect=/videos")],
-      }
-    })
+  test("should fall back to home when redirect is an external URL", () => {
+    mockSearchParams = new URLSearchParams("?redirect=https://evil.example")
 
-    const router = createMemoryRouter([
-      {
-        path: "/login",
-        element: <LoginPage />,
-      },
-    ], { initialEntries: ["/login?redirect=/videos"] })
+    renderLoginPage()
 
-    render(<RouterProvider router={router} />)
+    fireEvent.click(screen.getByTestId("login-button"))
 
-    expect(screen.getByTestId("login-button")).toBeInTheDocument()
+    expect(mockNavigate).toHaveBeenCalledWith("/")
+  })
+
+  test("should fall back to home when redirect is a protocol-relative URL", () => {
+    mockSearchParams = new URLSearchParams("?redirect=//evil.example")
+
+    renderLoginPage()
+
+    fireEvent.click(screen.getByTestId("login-button"))
+
+    expect(mockNavigate).toHaveBeenCalledWith("/")
   })
 })


### PR DESCRIPTION
The login page passed the raw ?redirect= query value straight to navigate(), so a crafted link like /sign-in?redirect=https://evil.example could send a freshly-authenticated user off-site. The redirect value is now validated to only allow in-app paths (single leading slash, not protocol-relative), falling back to "/", and useRedirectOnAuth now URL-encodes the sign-in redirect target and preserves the query string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)