### PR TITLE
Fix interval leak in VideoMetadataCard hover animation

### DIFF
--- a/app/components/video/video-metadata-card/VideoMetadataCard.tsx
+++ b/app/components/video/video-metadata-card/VideoMetadataCard.tsx
@@ -27,7 +27,8 @@ type ImageDimensions = {
 
 const VideoMetadataCard: FC<VideoMetadataCardProps> = props => {
   const [maybeSnapshots, setMaybeSnapshots] = useState<Option<Snapshot[]>>(None.of())
-  const [maybeIntervalTimeout, setMaybeIntervalTimeout] = useState<Option<NodeJS.Timeout>>(None.of())
+  const [isHovering, setIsHovering] = useState<boolean>(false)
+  const intervalTimeoutRef = useRef<Option<NodeJS.Timeout>>(None.of<NodeJS.Timeout>())
   const [index, setIndex] = useState<number>(0)
   const imageRef = useRef<HTMLImageElement | null>(null)
   const [imageDimensions, setImageDimensions] = useState<Option<ImageDimensions>>(None.of<ImageDimensions>())
@@ -43,36 +44,31 @@ const VideoMetadataCard: FC<VideoMetadataCardProps> = props => {
         })
       )
 
-  const onMouseOver = () => {
-    if (!Option.fromNullable(props.disableSnapshots).getOrElse(() => false)) {
-      setMaybeIntervalTimeout(
-        Some.of(setInterval(() => setIndex((index) => index + 1), 400)
-        )
-      )
+  const onMouseEnter = () => {
+    if (!Option.fromNullable(props.disableSnapshots).getOrElse(() => false) && intervalTimeoutRef.current.isEmpty()) {
+      intervalTimeoutRef.current = Some.of(setInterval(() => setIndex((index) => index + 1), 400))
+      setIsHovering(true)
+      initializeSnapshots().catch((error) => console.error(error))
     }
   }
 
   const onMouseLeave = () => {
-    maybeIntervalTimeout.forEach(clearInterval)
-    setMaybeIntervalTimeout(None.of())
+    intervalTimeoutRef.current.forEach(clearInterval)
+    intervalTimeoutRef.current = None.of()
+    setIsHovering(false)
     setIndex(0)
   }
 
   useEffect(() => {
     return () => {
-      setMaybeSnapshots(None.of())
-      maybeIntervalTimeout.forEach(clearInterval)
+      intervalTimeoutRef.current.forEach(clearInterval)
     }
   }, [])
 
-  useEffect(() => {
-    maybeIntervalTimeout.forEach(initializeSnapshots)
-  }, [maybeIntervalTimeout])
-
   const thumbnail = (safeMode: boolean) =>
     imageUrl(
-      maybeIntervalTimeout
-        .flatMap(() => maybeSnapshots)
+      maybeSnapshots
+        .filter(() => isHovering)
         .filter((values) => values.length > 0)
         .fold<FileResource<FileResourceType.Thumbnail | FileResourceType.Snapshot>>(
           () => props.videoMetadata.thumbnail,
@@ -104,7 +100,7 @@ const VideoMetadataCard: FC<VideoMetadataCardProps> = props => {
   return (
     <div className={classNames(styles.videoMetadataCard, props.classNames)}>
       <div
-        onMouseOver={onMouseOver}
+        onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         className={styles.imageContainer}>
         { props.children }

--- a/tests/components/VideoMetadataCard.test.tsx
+++ b/tests/components/VideoMetadataCard.test.tsx
@@ -289,4 +289,85 @@ describe("VideoMetadataCard", () => {
     removeEventListenerSpy.mockRestore()
   })
 
+  test("should not start a second interval when hover fires again", async () => {
+    const { fetchVideoSnapshotsByVideoId } = await import("~/services/video/VideoService")
+    const setIntervalSpy = vi.spyOn(window, "setInterval")
+
+    renderWithContext(createMockVideoMetadata(), { disableSnapshots: false })
+
+    const container = screen.getByAltText("video thumbnail").parentElement!
+    fireEvent.mouseOver(container)
+    fireEvent.mouseOver(container)
+
+    await waitFor(() => {
+      expect(fetchVideoSnapshotsByVideoId).toHaveBeenCalledTimes(1)
+    })
+
+    const snapshotIntervalCalls = setIntervalSpy.mock.calls.filter(([, delay]) => delay === 400)
+    expect(snapshotIntervalCalls).toHaveLength(1)
+    setIntervalSpy.mockRestore()
+  })
+
+  test("should clear the interval on mouse leave", async () => {
+    const { fetchVideoSnapshotsByVideoId } = await import("~/services/video/VideoService")
+    const setIntervalSpy = vi.spyOn(window, "setInterval")
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval")
+
+    renderWithContext(createMockVideoMetadata(), { disableSnapshots: false })
+
+    const container = screen.getByAltText("video thumbnail").parentElement!
+    fireEvent.mouseOver(container)
+    const intervalId = setIntervalSpy.mock.results[0].value
+
+    await waitFor(() => {
+      expect(fetchVideoSnapshotsByVideoId).toHaveBeenCalled()
+    })
+
+    fireEvent.mouseLeave(container)
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId)
+    setIntervalSpy.mockRestore()
+    clearIntervalSpy.mockRestore()
+  })
+
+  test("should clear the interval on unmount", async () => {
+    const { fetchVideoSnapshotsByVideoId } = await import("~/services/video/VideoService")
+    const setIntervalSpy = vi.spyOn(window, "setInterval")
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval")
+
+    const { unmount } = renderWithContext(createMockVideoMetadata(), { disableSnapshots: false })
+
+    const container = screen.getByAltText("video thumbnail").parentElement!
+    fireEvent.mouseOver(container)
+    const intervalId = setIntervalSpy.mock.results[0].value
+
+    await waitFor(() => {
+      expect(fetchVideoSnapshotsByVideoId).toHaveBeenCalled()
+    })
+
+    unmount()
+
+    expect(clearIntervalSpy).toHaveBeenCalledWith(intervalId)
+    setIntervalSpy.mockRestore()
+    clearIntervalSpy.mockRestore()
+  })
+
+  test("should log an error when fetching snapshots fails", async () => {
+    const { fetchVideoSnapshotsByVideoId } = await import("~/services/video/VideoService")
+    vi.mocked(fetchVideoSnapshotsByVideoId).mockRejectedValueOnce(new Error("fetch failed"))
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    renderWithContext(createMockVideoMetadata(), { disableSnapshots: false })
+
+    const thumbnail = screen.getByAltText("video thumbnail")
+    fireEvent.mouseOver(thumbnail.parentElement!)
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: "fetch failed" }))
+    })
+
+    expect(thumbnail).toBeInTheDocument()
+    consoleErrorSpy.mockRestore()
+  })
+
 })


### PR DESCRIPTION
The hover snapshot animation used onMouseOver, which re-fires when the pointer crosses child elements and started a new setInterval each time while only the last one was ever cleared, and the unmount cleanup read a stale first-render value so it cleared nothing. This switches to onMouseEnter with the interval id held in a ref (guarded against double-starting, cleared on mouse leave and unmount) and adds a .catch for the snapshot fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)