### PR TITLE
Fix abort and error handling in usePaginatedFetch and InfiniteScroll

### DIFF
--- a/app/components/infinite-scroll/InfiniteScroll.tsx
+++ b/app/components/infinite-scroll/InfiniteScroll.tsx
@@ -13,27 +13,27 @@ type InfiniteScrollProps = {
 const InfiniteScroll: FC<InfiniteScrollProps> = props => {
     const loadingTrigger = useRef<HTMLDivElement | null>(null)
     const hasMore = useRef<boolean>(props.hasMore)
+    const loadMore = useRef<() => void>(props.loadMore)
 
     hasMore.current = props.hasMore
+    loadMore.current = props.loadMore
 
     useEffect(() => {
-        if (loadingTrigger.current != null) {
+        const element = loadingTrigger.current
+
+        if (element != null) {
             const intersectionObserver = new IntersectionObserver(entries => {
                 if (entries.length > 0) {
                     const entry = entries[0]
                     if (entry.isIntersecting && hasMore.current) {
-                        props.loadMore()
+                        loadMore.current()
                     }
                 }
             })
 
-            intersectionObserver.observe(loadingTrigger.current)
+            intersectionObserver.observe(element)
 
-            return () => {
-                if (loadingTrigger.current != null) {
-                    intersectionObserver.unobserve(loadingTrigger.current)
-                }
-            }
+            return () => intersectionObserver.disconnect()
         }
     }, []);
 

--- a/app/components/infinite-scroll/usePaginatedFetch.ts
+++ b/app/components/infinite-scroll/usePaginatedFetch.ts
@@ -12,6 +12,11 @@ interface PaginatedFetchOptions {
   readonly resetDeps?: DependencyList
 }
 
+// Covers both DOMException AbortError and axios CanceledError.
+const isAbortError = (error: unknown): boolean =>
+  (error instanceof DOMException && error.name === "AbortError") ||
+  (error instanceof Error && error.name === "CanceledError")
+
 /**
  * Encapsulates the infinite-scroll pagination control shared across pages:
  * page-number state, loading/has-more tracking, per-page de-duplication and the
@@ -52,11 +57,20 @@ export function usePaginatedFetch<T>(
 
   const loadPage = async (page: number) => {
     if (fetchedPages.current.has(page)) return
-    fetchedPages.current.add(page)
+
+    // Capture the controller and page set used for this request so that, after
+    // the await, a reset (which replaces both) can be detected.
+    const controller = abortController.current
+    const pages = fetchedPages.current
+    pages.add(page)
     setLoading(true)
 
     try {
-      const results = await fetchPageRef.current(page, abortController.current.signal)
+      const results = await fetchPageRef.current(page, controller.signal)
+
+      // A reset or unmount aborted this request while it was in flight; its
+      // results belong to a stale query, so drop them.
+      if (controller.signal.aborted) return
 
       if (results.length < pageSize) {
         hasMoreRef.current = false
@@ -64,14 +78,27 @@ export function usePaginatedFetch<T>(
       }
 
       await onResultsRef.current(results, page)
+    } catch (error) {
+      // Forget the page so a failed fetch can be retried.
+      pages.delete(page)
+
+      if (!isAbortError(error)) {
+        console.error(error)
+      }
     } finally {
-      setLoading(false)
+      // Only the request owning the current controller may flip the loading
+      // state; an aborted/stale request must not clobber a newer request's.
+      if (controller === abortController.current) {
+        setLoading(false)
+      }
     }
   }
 
   // Initial load, and reset whenever the reset dependencies change.
   useEffect(() => {
-    abortController.current = new AbortController()
+    abortController.current.abort()
+    const controller = new AbortController()
+    abortController.current = controller
     fetchedPages.current = new Set<number>()
     hasMoreRef.current = true
     setHasMore(true)
@@ -82,6 +109,8 @@ export function usePaginatedFetch<T>(
     } else {
       setPageNumber(0)
     }
+
+    return () => controller.abort()
   }, resetDeps)
 
   // Load the next page whenever the page number advances.

--- a/app/pages/authenticated/playlists/components/VideoSearchPanel.tsx
+++ b/app/pages/authenticated/playlists/components/VideoSearchPanel.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useState, useEffect, useRef } from "react"
+import React, { type FC, useState, useEffect } from "react"
 import { CircularProgress } from "@mui/material"
 import { Video } from "~/models/Video"
 import { searchVideos } from "~/services/video/VideoService"
@@ -11,6 +11,7 @@ import { type Range } from "~/models/Range"
 import VideoSearch from "~/pages/authenticated/videos/components/VideoSearch"
 import DraggableSearchVideoCard from "./DraggableSearchVideoCard"
 import InfiniteScroll from "~/components/infinite-scroll/InfiniteScroll"
+import { usePaginatedFetch } from "~/components/infinite-scroll/usePaginatedFetch"
 
 import styles from "./VideoSearchPanel.module.scss"
 
@@ -26,6 +27,21 @@ const DEFAULT_SIZE_RANGE: Range<number> = {
 
 const PAGE_SIZE = 20
 
+const SEARCH_DEBOUNCE_MS = 300
+
+// Trails the given value by `delayMs`, so rapid changes (e.g. typing) only
+// produce one update once the input settles.
+function useDebouncedValue<A>(value: A, delayMs: number): A {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return debouncedValue
+}
+
 type VideoSearchPanelProps = {
   readonly onVideoSelect: (videoId: string) => Promise<void>
   readonly existingVideoIds: string[]
@@ -39,101 +55,30 @@ const VideoSearchPanel: FC<VideoSearchPanelProps> = ({ onVideoSelect, existingVi
   const [sizeRange, setSizeRange] = useState<Range<number>>(DEFAULT_SIZE_RANGE)
   const [videoSites, setVideoSites] = useState<string[]>([])
   const [videos, setVideos] = useState<Video[]>([])
-  const [isLoading, setIsLoading] = useState(false)
   const [addingVideoId, setAddingVideoId] = useState<Option<string>>(None.of())
-  const [pageNumber, setPageNumber] = useState(0)
 
-  const abortControllerRef = useRef<AbortController | null>(null)
-  const hasMore = useRef(true)
-  const isLoadingMore = useRef(false)
-  const fetchedPages = useRef(new Set<number>())
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, SEARCH_DEBOUNCE_MS)
 
-  const loadVideos = async (page: number, isNewSearch: boolean) => {
-    if (fetchedPages.current.has(page) && !isNewSearch) {
-      return
-    }
-
-    if (abortControllerRef.current && isNewSearch) {
-      abortControllerRef.current.abort()
-    }
-
-    const abortController = new AbortController()
-    abortControllerRef.current = abortController
-
-    if (isNewSearch) {
-      setIsLoading(true)
-    }
-
-    try {
-      fetchedPages.current.add(page)
-
-      const result = await searchVideos(
-        searchTerm,
+  const { isLoading, hasMore, loadMore } = usePaginatedFetch<Video>(
+    (pageNumber, signal) =>
+      searchVideos(
+        debouncedSearchTerm,
         durationRange,
         sizeRange,
         videoSites,
-        page,
+        pageNumber,
         PAGE_SIZE,
         sortBy,
         ordering,
-        abortController.signal
-      )
-
-      if (result.results.length < PAGE_SIZE) {
-        hasMore.current = false
-      }
-
-      if (isNewSearch) {
-        setVideos(result.results)
-      } else {
-        setVideos(prev => [...prev, ...result.results])
-      }
-    } catch (error) {
-      if ((error as Error).name !== "CanceledError") {
-        console.error("Search error:", error)
-      }
-      fetchedPages.current.delete(page)
-    } finally {
-      setIsLoading(false)
-      isLoadingMore.current = false
+        signal
+      ).then(result => result.results),
+    (results, pageNumber) =>
+      setVideos(videos => (pageNumber === 0 ? results : videos.concat(results))),
+    {
+      pageSize: PAGE_SIZE,
+      resetDeps: [debouncedSearchTerm, sortBy, ordering, durationRange, sizeRange, videoSites]
     }
-  }
-
-  // Initial search and search param changes
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      // Reset pagination state for new search
-      setPageNumber(0)
-      setVideos([])
-      hasMore.current = true
-      fetchedPages.current = new Set<number>()
-      loadVideos(0, true)
-    }, 300)
-
-    return () => clearTimeout(timer)
-  }, [searchTerm, sortBy, ordering, durationRange, sizeRange, videoSites])
-
-  // Load more pages
-  useEffect(() => {
-    if (pageNumber > 0) {
-      loadVideos(pageNumber, false)
-    }
-  }, [pageNumber])
-
-  useEffect(() => {
-    return () => {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-      }
-    }
-  }, [])
-
-  const loadMore = () => {
-    if (!isLoadingMore.current && hasMore.current && !isLoading) {
-      isLoadingMore.current = true
-      setPageNumber(prev => prev + 1)
-    }
-  }
+  )
 
   const handleAddVideo = async (videoId: string) => {
     setAddingVideoId(Some.of(videoId))
@@ -176,7 +121,7 @@ const VideoSearchPanel: FC<VideoSearchPanelProps> = ({ onVideoSelect, existingVi
       {filteredVideos.length > 0 && (
         <InfiniteScroll
           loadMore={loadMore}
-          hasMore={hasMore.current}
+          hasMore={hasMore}
           className={styles.results}
         >
           <p className={styles.resultsHint}>
@@ -197,7 +142,7 @@ const VideoSearchPanel: FC<VideoSearchPanelProps> = ({ onVideoSelect, existingVi
               />
             )
           })}
-          {isLoadingMore.current && (
+          {isLoading && (
             <div className={styles.loadingMore}>
               <CircularProgress size={20} />
             </div>

--- a/tests/components/InfiniteScroll.test.tsx
+++ b/tests/components/InfiniteScroll.test.tsx
@@ -1,12 +1,13 @@
 import { describe, expect, test, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import InfiniteScroll from "~/components/infinite-scroll/InfiniteScroll"
-import { intersectionObserverCallbacks } from "../setup"
+import { intersectionObserverCallbacks, intersectionObserverInstances } from "../setup"
 
 describe("InfiniteScroll", () => {
   beforeEach(() => {
-    // Clear the callbacks array before each test
+    // Clear the callbacks and instances arrays before each test
     intersectionObserverCallbacks.length = 0
+    intersectionObserverInstances.length = 0
   })
 
   test("should render children", () => {
@@ -157,7 +158,7 @@ describe("InfiniteScroll", () => {
     expect(loadMore).not.toHaveBeenCalled()
   })
 
-  test("should call unobserve on cleanup when unmounted", () => {
+  test("should disconnect the observer on cleanup when unmounted", () => {
     const loadMore = vi.fn()
     const { unmount } = render(
       <InfiniteScroll loadMore={loadMore} hasMore={true}>
@@ -166,16 +167,18 @@ describe("InfiniteScroll", () => {
     )
 
     // Verify IntersectionObserver was created
-    expect(intersectionObserverCallbacks.length).toBeGreaterThan(0)
+    expect(intersectionObserverInstances.length).toBeGreaterThan(0)
+
+    const observer = intersectionObserverInstances[intersectionObserverInstances.length - 1]
+    expect(observer.disconnect).not.toHaveBeenCalled()
 
     // Unmount the component to trigger cleanup
     unmount()
 
-    // The cleanup function should have been called
-    // Note: The actual unobserve call is internal to the IntersectionObserver mock
+    expect(observer.disconnect).toHaveBeenCalledTimes(1)
   })
 
-  test("should cleanup properly when ref is still valid", () => {
+  test("should observe the loading trigger and disconnect it on unmount", () => {
     const loadMore = vi.fn()
     const { unmount, container } = render(
       <InfiniteScroll loadMore={loadMore} hasMore={true}>
@@ -183,10 +186,40 @@ describe("InfiniteScroll", () => {
       </InfiniteScroll>
     )
 
-    // Verify component rendered with trigger div
-    expect(container.querySelector("div > div")).toBeInTheDocument()
+    // The sentinel is the last child of the scroll container
+    const sentinel = container.firstChild?.lastChild
 
-    // Unmount should cleanup without errors
-    expect(() => unmount()).not.toThrow()
+    const observer = intersectionObserverInstances[intersectionObserverInstances.length - 1]
+    expect(observer.observe).toHaveBeenCalledTimes(1)
+    expect(observer.observe).toHaveBeenCalledWith(sentinel)
+
+    unmount()
+
+    expect(observer.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  test("should call the latest loadMore callback after a rerender", () => {
+    const initialLoadMore = vi.fn()
+    const updatedLoadMore = vi.fn()
+    const { rerender } = render(
+      <InfiniteScroll loadMore={initialLoadMore} hasMore={true}>
+        <div>Content</div>
+      </InfiniteScroll>
+    )
+
+    rerender(
+      <InfiniteScroll loadMore={updatedLoadMore} hasMore={true}>
+        <div>Content</div>
+      </InfiniteScroll>
+    )
+
+    const callback = intersectionObserverCallbacks[intersectionObserverCallbacks.length - 1]
+    const mockEntry: Partial<IntersectionObserverEntry> = {
+      isIntersecting: true,
+    }
+    callback([mockEntry as IntersectionObserverEntry], {} as IntersectionObserver)
+
+    expect(initialLoadMore).not.toHaveBeenCalled()
+    expect(updatedLoadMore).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/components/usePaginatedFetch.test.tsx
+++ b/tests/components/usePaginatedFetch.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, test, vi, afterEach } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { usePaginatedFetch } from "~/components/infinite-scroll/usePaginatedFetch"
+
+type Deferred<T> = {
+  readonly promise: Promise<T>
+  readonly resolve: (value: T) => void
+  readonly reject: (error: unknown) => void
+}
+
+const deferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+type Request = {
+  readonly page: number
+  readonly signal: AbortSignal
+  readonly result: Deferred<string[]>
+}
+
+const deferredFetchPage = (requests: Request[]) =>
+  vi.fn((page: number, signal: AbortSignal) => {
+    const result = deferred<string[]>()
+    requests.push({ page, signal, result })
+    return result.promise
+  })
+
+describe("usePaginatedFetch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("should fetch page 0 once on mount and pass results to onResults", async () => {
+    const fetchPage = vi.fn().mockResolvedValue(["a", "b"])
+    const onResults = vi.fn()
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchPage, onResults, { pageSize: 2 }))
+
+    await waitFor(() => expect(onResults).toHaveBeenCalledWith(["a", "b"], 0))
+
+    // Both mount effects attempt page 0; per-page de-dup keeps it to one fetch
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+    expect(result.current.hasMore).toBe(true)
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  test("should set hasMore to false when a page is shorter than pageSize", async () => {
+    const fetchPage = vi.fn().mockResolvedValue(["only-one"])
+    const onResults = vi.fn()
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchPage, onResults, { pageSize: 2 }))
+
+    await waitFor(() => expect(result.current.hasMore).toBe(false))
+    expect(onResults).toHaveBeenCalledWith(["only-one"], 0)
+  })
+
+  test("should fetch the next page when loadMore is called", async () => {
+    const fetchPage = vi.fn().mockResolvedValue(["a", "b"])
+    const onResults = vi.fn()
+
+    const { result } = renderHook(() => usePaginatedFetch(fetchPage, onResults, { pageSize: 2 }))
+
+    await waitFor(() => expect(onResults).toHaveBeenCalledWith(["a", "b"], 0))
+
+    act(() => result.current.loadMore())
+
+    await waitFor(() => expect(onResults).toHaveBeenCalledWith(["a", "b"], 1))
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  test("should abort the in-flight request when resetDeps change and drop its stale results", async () => {
+    const requests: Request[] = []
+    const fetchPage = deferredFetchPage(requests)
+    const onResults = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ term }) => usePaginatedFetch(fetchPage, onResults, { pageSize: 2, resetDeps: [term] }),
+      { initialProps: { term: "first" } }
+    )
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0].signal.aborted).toBe(false)
+
+    rerender({ term: "second" })
+
+    expect(requests[0].signal.aborted).toBe(true)
+    expect(requests).toHaveLength(2)
+    expect(requests[1].signal.aborted).toBe(false)
+
+    // The new query's response arrives first...
+    await act(async () => requests[1].result.resolve(["new-1", "new-2"]))
+    // ...and the slow stale response resolves afterwards
+    await act(async () => requests[0].result.resolve(["stale-1", "stale-2"]))
+
+    expect(onResults).toHaveBeenCalledTimes(1)
+    expect(onResults).toHaveBeenCalledWith(["new-1", "new-2"], 0)
+  })
+
+  test("should abort the in-flight request on unmount and not call onResults afterwards", async () => {
+    const requests: Request[] = []
+    const fetchPage = deferredFetchPage(requests)
+    const onResults = vi.fn()
+
+    const { unmount } = renderHook(() => usePaginatedFetch(fetchPage, onResults, { pageSize: 2 }))
+
+    expect(requests).toHaveLength(1)
+
+    unmount()
+
+    expect(requests[0].signal.aborted).toBe(true)
+
+    await act(async () => requests[0].result.resolve(["late-1", "late-2"]))
+
+    expect(onResults).not.toHaveBeenCalled()
+  })
+
+  test("should log a failed fetch, leave it retryable and retry it on reset", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const error = new Error("network down")
+    const fetchPage = vi
+      .fn()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(["a", "b"])
+    const onResults = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ term }) => usePaginatedFetch(fetchPage, onResults, { pageSize: 2, resetDeps: [term] }),
+      { initialProps: { term: "first" } }
+    )
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalledWith(error))
+    expect(onResults).not.toHaveBeenCalled()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.hasMore).toBe(true)
+
+    // The failed page is not poisoned: a reset fetches page 0 again
+    rerender({ term: "second" })
+
+    await waitFor(() => expect(onResults).toHaveBeenCalledWith(["a", "b"], 0))
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  test.each([
+    ["AbortError", new DOMException("The operation was aborted", "AbortError")],
+    ["CanceledError", Object.assign(new Error("canceled"), { name: "CanceledError" })]
+  ])("should swallow %s rejections without logging", async (_name, abortError) => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const fetchPage = vi.fn().mockRejectedValue(abortError)
+    const onResults = vi.fn()
+
+    renderHook(() => usePaginatedFetch(fetchPage, onResults, { pageSize: 2 }))
+
+    // Flush the rejected fetch
+    await act(async () => undefined)
+
+    expect(onResults).not.toHaveBeenCalled()
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -23,10 +23,12 @@ Object.defineProperty(window, "matchMedia", {
 })
 
 // Mock IntersectionObserver with configurable callback
-// Store callbacks so tests can trigger intersection events
+// Store callbacks so tests can trigger intersection events, and instances so
+// tests can assert on observe/unobserve/disconnect calls
 export const intersectionObserverCallbacks: IntersectionObserverCallback[] = []
+export const intersectionObserverInstances: MockIntersectionObserver[] = []
 
-class MockIntersectionObserver implements IntersectionObserver {
+export class MockIntersectionObserver implements IntersectionObserver {
   readonly root: Element | Document | null = null
   readonly rootMargin: string = ""
   readonly scrollMargin: string = ""
@@ -36,6 +38,7 @@ class MockIntersectionObserver implements IntersectionObserver {
   constructor(callback: IntersectionObserverCallback) {
     this.callback = callback
     intersectionObserverCallbacks.push(callback)
+    intersectionObserverInstances.push(this)
   }
 
   observe = vi.fn()


### PR DESCRIPTION
usePaginatedFetch now aborts the in-flight request when resetDeps change or the component unmounts, drops stale aborted responses instead of letting a slow old query overwrite newer results, and catches fetch failures (logging non-abort errors and removing the failed page from the de-dup set so it can be retried) instead of leaking unhandled rejections. InfiniteScroll keeps loadMore in a ref so its one-time IntersectionObserver effect always calls the latest callback, and its cleanup now disconnects the observer. Tests cover the abort/stale-drop/retry behaviour and assert on the mocked observer's observe/disconnect calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)