### PR TITLE
Make logout resilient to server-side failures

### DIFF
--- a/app/components/quick-settings/switches/LogoutButton.tsx
+++ b/app/components/quick-settings/switches/LogoutButton.tsx
@@ -7,8 +7,14 @@ const LogoutButton = () => {
   const navigate = useNavigate()
 
   const handleLogout = async () => {
-    await logout()
-    navigate("/sign-in")
+    try {
+      await logout()
+    } catch (error) {
+      // The local session is cleared even when the server-side logout fails
+      console.error("Server-side logout failed", error)
+    } finally {
+      navigate("/sign-in")
+    }
   }
 
   return (

--- a/app/services/authentication/AuthenticationService.ts
+++ b/app/services/authentication/AuthenticationService.ts
@@ -51,12 +51,13 @@ export const getAuthenticatedUser = async (): Promise<User> => {
 }
 
 export const logout = async (): Promise<User> => {
-  const response = await axiosClient.delete("authentication/logout")
-  removeAuthenticationToken()
+  try {
+    const response = await axiosClient.delete("authentication/logout")
 
-  const user = zodParse(User, response.data)
-
-  return user
+    return zodParse(User, response.data)
+  } finally {
+    removeAuthenticationToken()
+  }
 }
 
 export const removeAuthenticationToken = (): Option<AuthenticationToken> =>

--- a/tests/components/LogoutButton.test.tsx
+++ b/tests/components/LogoutButton.test.tsx
@@ -70,4 +70,27 @@ describe("LogoutButton", () => {
       expect(screen.getByText("Sign In Page")).toBeInTheDocument()
     })
   })
+
+  test("should still navigate to sign-in page when logout fails", async () => {
+    const user = userEvent.setup()
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    mockLogout.mockRejectedValue(new Error("Network error"))
+
+    renderWithRouter()
+
+    const logoutButton = screen.getByRole("button", { name: /logout/i })
+    await user.click(logoutButton)
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign In Page")).toBeInTheDocument()
+    })
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Server-side logout failed", expect.any(Error))
+
+    consoleErrorSpy.mockRestore()
+  })
 })

--- a/tests/services/AuthenticationService.test.ts
+++ b/tests/services/AuthenticationService.test.ts
@@ -113,6 +113,24 @@ describe("AuthenticationService", () => {
       expect(result.email).toBe("test@example.com")
       expect(result.firstName).toBe("Test")
     })
+
+    test("should remove the stored authentication token on success", async () => {
+      localStorage.setItem("Authentication-Token", JSON.stringify(mockTokenData))
+      mockAxiosDelete.mockResolvedValue({ data: mockUserData })
+
+      await logout()
+
+      expect(localStorage.getItem("Authentication-Token")).toBeNull()
+    })
+
+    test("should remove the stored authentication token even when the API call fails", async () => {
+      localStorage.setItem("Authentication-Token", JSON.stringify(mockTokenData))
+      mockAxiosDelete.mockRejectedValue(new Error("Network error"))
+
+      await expect(logout()).rejects.toThrow("Network error")
+
+      expect(localStorage.getItem("Authentication-Token")).toBeNull()
+    })
   })
 
   // Tests for getAuthenticationToken and removeAuthenticationToken are skipped


### PR DESCRIPTION
Clicking Logout did nothing when the server call failed: the stored auth token was only removed after a successful response, and the unhandled rejection prevented navigation. logout() now clears the token in a finally block, and LogoutButton always navigates to the sign-in page, logging any server-side error instead of leaking it as an unhandled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)