### PR TITLE
Fix getEnvironment returning string enum keys instead of Environment values

### DIFF
--- a/app/services/Config.ts
+++ b/app/services/Config.ts
@@ -19,6 +19,6 @@ export const getEnvironment = (): Environment => {
   const host: string = window.location.host
 
   return Option.fromNullable(Object.entries(URL_MAPPINGS).find(([_, hosts]) => hosts.includes(host)))
-    .map(([env]) => env as unknown as Environment)
+    .map(([env]) => Number(env) as Environment)
     .getOrElse(() => Environment.Development)
 }

--- a/tests/services/Config.test.ts
+++ b/tests/services/Config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest"
+
+describe("Config", () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  const stubHost = (host: string) => {
+    vi.stubGlobal("window", {
+      location: { host },
+    })
+  }
+
+  describe("getEnvironment", () => {
+    test("should return Environment.Production for the production host", async () => {
+      stubHost("videos.ruchij.com")
+
+      const { Environment, getEnvironment } = await import("~/services/Config")
+
+      expect(getEnvironment()).toBe(Environment.Production)
+    })
+
+    test("should return Environment.Staging for the staging host", async () => {
+      stubHost("staging.videos.ruchij.com")
+
+      const { Environment, getEnvironment } = await import("~/services/Config")
+
+      expect(getEnvironment()).toBe(Environment.Staging)
+    })
+
+    test("should return Environment.Development for an unknown host", async () => {
+      stubHost("unknown-host.example.com")
+
+      const { Environment, getEnvironment } = await import("~/services/Config")
+
+      expect(getEnvironment()).toBe(Environment.Development)
+    })
+
+    test("should return Environment.Development for localhost", async () => {
+      stubHost("localhost:3000")
+
+      const { Environment, getEnvironment } = await import("~/services/Config")
+
+      expect(getEnvironment()).toBe(Environment.Development)
+    })
+  })
+})


### PR DESCRIPTION
getEnvironment() iterated URL_MAPPINGS with Object.entries, whose string keys were double-cast to Environment, so staging/production hosts yielded the strings "1"/"2" rather than the numeric enum values — any strict comparison like getEnvironment() === Environment.Production would silently fail. The key is now converted back with Number(env), and new tests in tests/services/Config.test.ts assert strict equality on the enum values for production, staging, and unknown hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)