### PR TITLE
Fix Sentry initialization timing, 404 noise, and dev/prod sampling

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,6 +7,12 @@ import { ApplicationConfigurationProvider } from "~/providers/ApplicationConfigu
 import smallLogo from "~/images/small-logo.svg"
 import { initSentry } from "~/services/Sentry"
 
+// Initialize at module scope so module-evaluation, hydration, and first-render errors are
+// captured. The production build runs an SSR prerender pass over this module, so skip on the server.
+if (typeof window !== "undefined") {
+  initSentry()
+}
+
 export function meta(_args: Route.MetaArgs) {
   return [
     {title: "Video Downloader"},
@@ -46,10 +52,6 @@ export function Layout({children}: { children: ReactNode }) {
 }
 
 export default function App() {
-  useEffect(() => {
-    initSentry()
-  }, [])
-
   return (
     <ApplicationConfigurationProvider>
       <Outlet />
@@ -90,7 +92,12 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
     stack = error.stack;
   }
 
-  captureException(error)
+  useEffect(() => {
+    // 404s aren't exceptions; report everything else once per error
+    if (!(isRouteErrorResponse(error) && error.status === 404)) {
+      captureException(error)
+    }
+  }, [error])
 
   return (
     <main className="pt-16 p-4 container mx-auto">

--- a/app/services/Sentry.ts
+++ b/app/services/Sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react"
 import { Environment, getEnvironment } from "~/services/Config"
+import { Option } from "~/types/Option"
 
 const DSN_MAPPINGS: Record<Environment, string> = {
   [Environment.Development]: "https://3cefa278484696cde7ff9e066525fa87@o4510770741837824.ingest.us.sentry.io/4510771763085312",
@@ -7,10 +8,21 @@ const DSN_MAPPINGS: Record<Environment, string> = {
   [Environment.Production]: "https://77f336ea08b08c576b93c76458db362f@o4510770741837824.ingest.us.sentry.io/4510771752992768"
 }
 
-const getDsn = () => {
-  const environment: Environment = getEnvironment()
-  return DSN_MAPPINGS[environment]
+const ENVIRONMENT_NAMES: Record<Environment, string> = {
+  [Environment.Development]: "development",
+  [Environment.Staging]: "staging",
+  [Environment.Production]: "production"
 }
+
+const TRACES_SAMPLE_RATES: Record<Environment, number> = {
+  [Environment.Development]: 1.0,
+  [Environment.Staging]: 1.0,
+  [Environment.Production]: 0.1
+}
+
+// getEnvironment() may return enum keys as strings ("1"/"2") instead of enum values;
+// normalize so this module works with either form
+const normalizedEnvironment = (): Environment => Number(getEnvironment()) as Environment
 
 let sentryInitialized = false
 
@@ -18,15 +30,26 @@ export const initSentry = () => {
   if (sentryInitialized) {
     return
   }
+
+  const environment: Environment = normalizedEnvironment()
+  const dsnOverride: Option<string> =
+    Option.fromNullable<string>(import.meta.env.VITE_SENTRY_DSN).filter(dsn => dsn.length > 0)
+
+  // Don't ship local-dev traces/replays to Sentry unless a DSN is explicitly configured
+  if (environment === Environment.Development && dsnOverride.isEmpty()) {
+    return
+  }
+
   sentryInitialized = true
 
   Sentry.init({
-    dsn: getDsn(),
+    dsn: dsnOverride.getOrElse(() => DSN_MAPPINGS[environment]),
+    environment: ENVIRONMENT_NAMES[environment],
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration()
     ],
-    tracesSampleRate: 1.0,
+    tracesSampleRate: TRACES_SAMPLE_RATES[environment],
     replaysSessionSampleRate: 0.1,
     replaysOnErrorSampleRate: 1.0
   })

--- a/tests/root.test.tsx
+++ b/tests/root.test.tsx
@@ -1,9 +1,19 @@
-import { describe, expect, test, vi } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { meta, links, Layout, HydrateFallback, ErrorBoundary } from "~/root"
+import { initSentry } from "~/services/Sentry"
 import React from "react"
 
 const mockIsRouteErrorResponse = vi.fn()
+const mockCaptureException = vi.fn()
+
+vi.mock("~/services/Sentry", () => ({
+  initSentry: vi.fn(),
+}))
+
+vi.mock("@sentry/react", () => ({
+  captureException: (error: unknown) => mockCaptureException(error),
+}))
 
 vi.mock("react-router", () => ({
   isRouteErrorResponse: (error: any) => mockIsRouteErrorResponse(error),
@@ -21,6 +31,16 @@ vi.mock("~/providers/ApplicationConfigurationProvider", () => ({
 }))
 
 describe("root", () => {
+  beforeEach(() => {
+    mockCaptureException.mockClear()
+  })
+
+  describe("Sentry initialization", () => {
+    test("should initialize Sentry at module scope", () => {
+      expect(initSentry).toHaveBeenCalled()
+    })
+  })
+
   describe("meta", () => {
     test("should return correct meta tags", () => {
       const result = meta({} as any)
@@ -91,6 +111,35 @@ describe("root", () => {
 
       expect(screen.getByText("Error")).toBeInTheDocument()
       expect(screen.getByText("Internal Server Error")).toBeInTheDocument()
+    })
+
+    test("should not capture 404 route errors", () => {
+      const routeError = { status: 404, statusText: "Not Found" }
+      mockIsRouteErrorResponse.mockReturnValue(true)
+
+      render(<ErrorBoundary error={routeError as any} params={defaultParams} />)
+
+      expect(mockCaptureException).not.toHaveBeenCalled()
+    })
+
+    test("should capture non-404 route errors", () => {
+      const routeError = { status: 500, statusText: "Internal Server Error" }
+      mockIsRouteErrorResponse.mockReturnValue(true)
+
+      render(<ErrorBoundary error={routeError as any} params={defaultParams} />)
+
+      expect(mockCaptureException).toHaveBeenCalledExactlyOnceWith(routeError)
+    })
+
+    test("should capture real errors once even across re-renders", () => {
+      const error = new Error("Test error")
+      mockIsRouteErrorResponse.mockReturnValue(false)
+
+      const { rerender } = render(<ErrorBoundary error={error} params={defaultParams} />)
+      rerender(<ErrorBoundary error={error} params={defaultParams} />)
+      rerender(<ErrorBoundary error={error} params={defaultParams} />)
+
+      expect(mockCaptureException).toHaveBeenCalledExactlyOnceWith(error)
     })
   })
 })

--- a/tests/services/Sentry.test.ts
+++ b/tests/services/Sentry.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { Environment } from "~/services/Config"
+
+const mockInit = vi.fn()
+const mockGetEnvironment = vi.fn()
+
+vi.mock("@sentry/react", () => ({
+  init: (options: unknown) => mockInit(options),
+  browserTracingIntegration: () => "browser-tracing-integration",
+  replayIntegration: () => "replay-integration",
+}))
+
+vi.mock("~/services/Config", async () => {
+  const actual = await vi.importActual<typeof import("~/services/Config")>("~/services/Config")
+  return {
+    ...actual,
+    getEnvironment: () => mockGetEnvironment(),
+  }
+})
+
+const loadInitSentry = async () => {
+  vi.resetModules()
+  const { initSentry } = await import("~/services/Sentry")
+  return initSentry
+}
+
+describe("initSentry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  test("should not initialize Sentry in Development without VITE_SENTRY_DSN", async () => {
+    mockGetEnvironment.mockReturnValue(Environment.Development)
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+
+    expect(mockInit).not.toHaveBeenCalled()
+  })
+
+  test("should initialize Sentry in Development when VITE_SENTRY_DSN is set", async () => {
+    mockGetEnvironment.mockReturnValue(Environment.Development)
+    vi.stubEnv("VITE_SENTRY_DSN", "https://custom@self-hosted.example.com/1")
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        dsn: "https://custom@self-hosted.example.com/1",
+        environment: "development",
+        tracesSampleRate: 1.0,
+      })
+    )
+  })
+
+  test("should initialize Sentry in Production with a reduced traces sample rate", async () => {
+    mockGetEnvironment.mockReturnValue(Environment.Production)
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        dsn: "https://77f336ea08b08c576b93c76458db362f@o4510770741837824.ingest.us.sentry.io/4510771752992768",
+        environment: "production",
+        tracesSampleRate: 0.1,
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1.0,
+      })
+    )
+  })
+
+  test("should initialize Sentry in Staging with full trace sampling", async () => {
+    mockGetEnvironment.mockReturnValue(Environment.Staging)
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        dsn: "https://0c16af37660ae085a000b8b8f9d79a17@o4510770741837824.ingest.us.sentry.io/4510771760791552",
+        environment: "staging",
+        tracesSampleRate: 1.0,
+      })
+    )
+  })
+
+  test("should handle getEnvironment returning enum keys as strings", async () => {
+    // getEnvironment() currently returns enum keys ("1"/"2") for staging/prod
+    mockGetEnvironment.mockReturnValue("2" as unknown as Environment)
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        environment: "production",
+        tracesSampleRate: 0.1,
+      })
+    )
+  })
+
+  test("should prefer VITE_SENTRY_DSN over the environment DSN mapping", async () => {
+    mockGetEnvironment.mockReturnValue(Environment.Production)
+    vi.stubEnv("VITE_SENTRY_DSN", "https://override@self-hosted.example.com/2")
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        dsn: "https://override@self-hosted.example.com/2",
+        environment: "production",
+      })
+    )
+  })
+
+  test("should only initialize Sentry once", async () => {
+    mockGetEnvironment.mockReturnValue(Environment.Production)
+
+    const initSentry = await loadInitSentry()
+    initSentry()
+    initSentry()
+
+    expect(mockInit).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Sentry is now initialized at module scope in root.tsx (guarded for the SSR prerender pass) so hydration and first-render errors are captured, and ErrorBoundary reports errors once via useEffect instead of on every re-render, skipping route 404s. Sentry.ts no longer initializes in local development unless VITE_SENTRY_DSN is set (which also overrides the DSN in any environment), passes the environment explicitly, and uses a 0.1 traces sample rate in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)