### PR TITLE
Stop persisting auth token secret and short-circuit expired sessions

### DIFF
--- a/app/models/AuthenticationToken.ts
+++ b/app/models/AuthenticationToken.ts
@@ -9,3 +9,12 @@ export const AuthenticationToken = z.object({
 })
 
 export type AuthenticationToken = z.infer<typeof AuthenticationToken>
+
+/**
+ * Persisted form of the authentication token. The `secret` is deliberately omitted:
+ * authentication rides on cookies, so the secret never needs to be stored where XSS
+ * could read it. Decoding strips a `secret` left behind by older stored entries.
+ */
+export const StoredAuthenticationToken = AuthenticationToken.omit({ secret: true })
+
+export type StoredAuthenticationToken = z.infer<typeof StoredAuthenticationToken>

--- a/app/pages/useRedirectOnAuth.ts
+++ b/app/pages/useRedirectOnAuth.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 import { useNavigate } from "react-router"
+import { DateTime } from "luxon"
 import {
   getAuthenticatedUser,
   getAuthenticationToken,
@@ -13,15 +14,24 @@ import {
  * When `redirectWhenAuthenticated` is true (public/unauthenticated layout), a valid
  * session redirects to the home page. When false (protected layout), a missing or
  * invalid session redirects to the sign-in page.
+ *
+ * A stored token whose `expiresAt` is in the past is treated as unauthenticated
+ * immediately: it is removed without a server round-trip.
  */
 export const useRedirectOnAuth = (redirectWhenAuthenticated: boolean): void => {
   const navigate = useNavigate()
 
   useEffect(() => {
     const maybeToken = getAuthenticationToken()
+    const maybeUnexpiredToken = maybeToken.filter((token) => token.expiresAt > DateTime.now())
+
+    if (!maybeToken.isEmpty() && maybeUnexpiredToken.isEmpty()) {
+      console.debug("Stored authentication token has expired. Removing authentication token.")
+      removeAuthenticationToken()
+    }
 
     if (redirectWhenAuthenticated) {
-      maybeToken.forEach(async () => {
+      maybeUnexpiredToken.forEach(async () => {
         try {
           await getAuthenticatedUser()
           navigate("/")
@@ -32,7 +42,7 @@ export const useRedirectOnAuth = (redirectWhenAuthenticated: boolean): void => {
     } else {
       const redirectUrl = `/sign-in?${REDIRECT_QUERY_PARAMETER}=${window.location.pathname}`
 
-      maybeToken.fold(
+      maybeUnexpiredToken.fold(
         () => {
           console.debug("Redirecting to sign-in page.")
           navigate(redirectUrl)

--- a/app/services/authentication/AuthenticationService.ts
+++ b/app/services/authentication/AuthenticationService.ts
@@ -1,5 +1,5 @@
 import { axiosClient } from "~/services/http/HttpClient"
-import { AuthenticationToken } from "~/models/AuthenticationToken"
+import { AuthenticationToken, StoredAuthenticationToken } from "~/models/AuthenticationToken"
 import { type KeySpace, LocalKeyValueStore } from "~/services/kv-store/KeyValueStore"
 import { User } from "~/models/User"
 import type { Option } from "~/types/Option"
@@ -7,7 +7,7 @@ import { zodParse } from "~/types/Zod"
 
 const AuthenticationKey = "Token" as const
 
-const AuthenticationKeySpace: KeySpace<typeof AuthenticationKey, AuthenticationToken> = {
+const AuthenticationKeySpace: KeySpace<typeof AuthenticationKey, StoredAuthenticationToken> = {
   name: "Authentication",
 
   keyEncoder: {
@@ -17,12 +17,13 @@ const AuthenticationKeySpace: KeySpace<typeof AuthenticationKey, AuthenticationT
   },
 
   valueCodec: {
-    decode(value: string): AuthenticationToken {
-      return zodParse(AuthenticationToken, JSON.parse(value))
+    decode(value: string): StoredAuthenticationToken {
+      // Lenient on purpose: older stored entries include a `secret`, which Zod strips here.
+      return zodParse(StoredAuthenticationToken, JSON.parse(value))
     },
 
-    encode(authenticationToken: AuthenticationToken): string {
-      return JSON.stringify(authenticationToken)
+    encode(storedAuthenticationToken: StoredAuthenticationToken): string {
+      return JSON.stringify(storedAuthenticationToken)
     },
   },
 }
@@ -31,14 +32,17 @@ const authenticationKeyValueStore = new LocalKeyValueStore(AuthenticationKeySpac
 
 export const REDIRECT_QUERY_PARAMETER = "redirect"
 
-export const getAuthenticationToken = (): Option<AuthenticationToken> =>
+export const getAuthenticationToken = (): Option<StoredAuthenticationToken> =>
   authenticationKeyValueStore.get(AuthenticationKey)
 
 export const login = async (email: string, password: string): Promise<AuthenticationToken> => {
   const response = await axiosClient.post("/authentication/login", { email, password })
   const authenticationToken = zodParse(AuthenticationToken, response.data)
 
-  authenticationKeyValueStore.put(AuthenticationKey, authenticationToken)
+  // Never persist the secret: authentication uses cookies, so the stored token is only
+  // a "logged in" marker and the secret would be gratuitous XSS-stealable material.
+  const { secret: _secret, ...storedAuthenticationToken } = authenticationToken
+  authenticationKeyValueStore.put(AuthenticationKey, storedAuthenticationToken)
 
   return authenticationToken
 }
@@ -59,5 +63,5 @@ export const logout = async (): Promise<User> => {
   return user
 }
 
-export const removeAuthenticationToken = (): Option<AuthenticationToken> =>
+export const removeAuthenticationToken = (): Option<StoredAuthenticationToken> =>
   authenticationKeyValueStore.remove(AuthenticationKey)

--- a/tests/pages/AuthenticatedLayout.test.tsx
+++ b/tests/pages/AuthenticatedLayout.test.tsx
@@ -7,10 +7,9 @@ import { None, Some } from "~/types/Option"
 import { DateTime } from "luxon"
 import { Role } from "~/models/User"
 
-const createMockToken = () => ({
-  secret: "test-token",
-  expiresAt: DateTime.now().plus({ hours: 1 }),
-  issuedAt: DateTime.now(),
+const createMockToken = (expiresAt = DateTime.now().plus({ hours: 1 })) => ({
+  expiresAt,
+  issuedAt: DateTime.now().minus({ days: 1 }),
   renewals: 0,
 })
 
@@ -130,6 +129,35 @@ describe("AuthenticatedLayout", () => {
       expect(removeAuthenticationToken).toHaveBeenCalled()
       expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=/videos")
     })
+  })
+
+  test("should redirect to sign-in without a server check when the token is expired", async () => {
+    const { getAuthenticationToken, getAuthenticatedUser, removeAuthenticationToken } =
+      await import("~/services/authentication/AuthenticationService")
+    vi.mocked(getAuthenticationToken).mockReturnValue(
+      Some.of(createMockToken(DateTime.now().minus({ hours: 1 })))
+    )
+
+    const router = createMemoryRouter([
+      {
+        path: "/",
+        element: <AuthenticatedLayout />,
+        children: [
+          {
+            index: true,
+            element: <div>Child</div>,
+          },
+        ],
+      },
+    ])
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(removeAuthenticationToken).toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=/videos")
+    })
+    expect(getAuthenticatedUser).not.toHaveBeenCalled()
   })
 
   test("should check authentication on mount", async () => {

--- a/tests/pages/UnauthenticatedLayout.test.tsx
+++ b/tests/pages/UnauthenticatedLayout.test.tsx
@@ -7,10 +7,9 @@ import { None, Some } from "~/types/Option"
 import { DateTime } from "luxon"
 import { Role } from "~/models/User"
 
-const createMockToken = () => ({
-  secret: "test-token",
-  expiresAt: DateTime.now().plus({ hours: 1 }),
-  issuedAt: DateTime.now(),
+const createMockToken = (expiresAt = DateTime.now().plus({ hours: 1 })) => ({
+  expiresAt,
+  issuedAt: DateTime.now().minus({ days: 1 }),
   renewals: 0,
 })
 
@@ -36,6 +35,7 @@ vi.mock("react-router", async () => {
 vi.mock("~/services/authentication/AuthenticationService", () => ({
   getAuthenticationToken: vi.fn(),
   getAuthenticatedUser: vi.fn(),
+  removeAuthenticationToken: vi.fn(),
 }))
 
 describe("UnauthenticatedLayout", () => {
@@ -141,5 +141,37 @@ describe("UnauthenticatedLayout", () => {
     // Wait a bit and check navigate was not called
     await new Promise(resolve => setTimeout(resolve, 50))
     expect(mockNavigate).not.toHaveBeenCalledWith("/")
+  })
+
+  test("should remove an expired token and stay on page without a server check", async () => {
+    const { getAuthenticationToken, getAuthenticatedUser, removeAuthenticationToken } =
+      await import("~/services/authentication/AuthenticationService")
+    vi.mocked(getAuthenticationToken).mockReturnValue(
+      Some.of(createMockToken(DateTime.now().minus({ hours: 1 })))
+    )
+
+    const router = createMemoryRouter([
+      {
+        path: "/",
+        element: <UnauthenticatedLayout />,
+        children: [
+          {
+            index: true,
+            element: <div data-testid="child">Child</div>,
+          },
+        ],
+      },
+    ])
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(removeAuthenticationToken).toHaveBeenCalled()
+    })
+
+    // Wait a bit and check no server round-trip or navigation happened
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(getAuthenticatedUser).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/AuthenticationService.test.ts
+++ b/tests/services/AuthenticationService.test.ts
@@ -15,6 +15,7 @@ import {
   login,
   logout,
   getAuthenticatedUser,
+  getAuthenticationToken,
   REDIRECT_QUERY_PARAMETER,
 } from "~/services/authentication/AuthenticationService"
 
@@ -39,8 +40,11 @@ describe("AuthenticationService", () => {
     role: "User",
   }
 
+  const STORAGE_KEY = "Authentication-Token"
+
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
   })
 
   describe("REDIRECT_QUERY_PARAMETER", () => {
@@ -74,6 +78,49 @@ describe("AuthenticationService", () => {
       mockAxiosPost.mockRejectedValue(new Error("Network error"))
 
       await expect(login("test@example.com", "password")).rejects.toThrow("Network error")
+    })
+
+    test("should persist the token without the secret", async () => {
+      mockAxiosPost.mockResolvedValue({ data: mockTokenData })
+
+      await login("test@example.com", "password123")
+
+      const storedValue = JSON.parse(localStorage.getItem(STORAGE_KEY) as string)
+
+      expect(storedValue).not.toHaveProperty("secret")
+      expect(storedValue.renewals).toBe(0)
+      expect(typeof storedValue.expiresAt).toBe("string")
+      expect(typeof storedValue.issuedAt).toBe("string")
+    })
+  })
+
+  describe("getAuthenticationToken", () => {
+    test("should return None when no token is stored", () => {
+      expect(getAuthenticationToken().isEmpty()).toBe(true)
+    })
+
+    test("should decode a stored token persisted by login", async () => {
+      mockAxiosPost.mockResolvedValue({ data: mockTokenData })
+
+      await login("test@example.com", "password123")
+
+      const token = getAuthenticationToken().toNullable()
+
+      expect(token).not.toBeNull()
+      expect(token).not.toHaveProperty("secret")
+      expect(token?.expiresAt.toISO()).toBe(mockTokenData.expiresAt)
+      expect(token?.renewals).toBe(0)
+    })
+
+    test("should decode legacy stored tokens that still contain a secret", () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(mockTokenData))
+
+      const token = getAuthenticationToken().toNullable()
+
+      expect(token).not.toBeNull()
+      expect(token).not.toHaveProperty("secret")
+      expect(token?.expiresAt.toISO()).toBe(mockTokenData.expiresAt)
+      expect(token?.renewals).toBe(0)
     })
   })
 
@@ -114,7 +161,4 @@ describe("AuthenticationService", () => {
       expect(result.firstName).toBe("Test")
     })
   })
-
-  // Tests for getAuthenticationToken and removeAuthenticationToken are skipped
-  // as they involve localStorage which requires more complex mocking with jsdom
 })


### PR DESCRIPTION
Authentication is cookie-based, so the token persisted to localStorage is only used as a logged-in marker — storing its secret was unnecessary XSS-stealable material. Login now persists the token without the secret (the stored schema leniently decodes legacy entries that still contain one), and useRedirectOnAuth now treats a token with a past expiresAt as unauthenticated immediately, removing it and skipping the getAuthenticatedUser() round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)