### PR TITLE
Use real form semantics in login and signup forms

### DIFF
--- a/app/pages/unauthenticated/login/components/login-form/LoginForm.tsx
+++ b/app/pages/unauthenticated/login/components/login-form/LoginForm.tsx
@@ -27,14 +27,20 @@ const LoginForm: FC<LoginFormProps> = props => {
   const [password, setPassword] = useState<string>("")
   const [showPassword, setShowPassword] = useState(false)
   const [errors, setErrors] = useState<Errors>(EMPTY_ERRORS)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const onChange = onFieldChange(() => setErrors(EMPTY_ERRORS))
 
-  const onLoginClick = async () => {
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (isSubmitting) return
+
     const isEmailValid = validateNonEmpty("email", email)
     const isPasswordValid = validateNonEmpty("password", password)
 
     if (isEmailValid && isPasswordValid) {
+      setIsSubmitting(true)
       try {
         const authenticationToken = await login(email, password)
         props.onAuthenticate(authenticationToken)
@@ -44,6 +50,8 @@ const LoginForm: FC<LoginFormProps> = props => {
           ...errors,
           response: errorMessages,
         }))
+      } finally {
+        setIsSubmitting(false)
       }
     }
   }
@@ -62,7 +70,7 @@ const LoginForm: FC<LoginFormProps> = props => {
         <h1 className={styles.title}>Video Downloader</h1>
         <p className={styles.subtitle}>Sign in to your account</p>
       </div>
-      <div className={styles.loginFormBody}>
+      <form className={styles.loginFormBody} onSubmit={onSubmit} noValidate>
         <div>
           <TextField
             error={errors.email != null}
@@ -71,6 +79,8 @@ const LoginForm: FC<LoginFormProps> = props => {
             label="Email"
             helperText={errors.email}
             type="email"
+            name="email"
+            autoComplete="email"
             className={styles.textField}
             fullWidth
           />
@@ -81,6 +91,8 @@ const LoginForm: FC<LoginFormProps> = props => {
             helperText={errors.password}
             label="Password"
             type={showPassword ? "text" : "password"}
+            name="password"
+            autoComplete="current-password"
             className={styles.textField}
             fullWidth
             slotProps={{
@@ -101,11 +113,11 @@ const LoginForm: FC<LoginFormProps> = props => {
           />
         </div>
         <div className={styles.loginButton}>
-          <Button onClick={onLoginClick} variant="contained" color="primary">
-            Login
+          <Button type="submit" variant="contained" color="primary" disabled={isSubmitting}>
+            {isSubmitting ? "Logging In..." : "Login"}
           </Button>
         </div>
-      </div>
+      </form>
       <ErrorMessages errors={errors.response} />
       <div className={styles.signupLink}>
         Don't have an account? <Link to="/sign-up">Sign up</Link>

--- a/app/pages/unauthenticated/signup/components/signup-form/SignupForm.tsx
+++ b/app/pages/unauthenticated/signup/components/signup-form/SignupForm.tsx
@@ -70,7 +70,11 @@ const SignupForm: FC<SignupFormProps> = props => {
     return true
   }
 
-  const onSignupClick = async () => {
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (isSubmitting) return
+
     const isFirstNameValid = validateNonEmpty("firstName", firstName, "First name")
     const isLastNameValid = validateNonEmpty("lastName", lastName, "Last name")
     const isEmailNonEmpty = validateNonEmpty("email", email, "Email")
@@ -105,7 +109,7 @@ const SignupForm: FC<SignupFormProps> = props => {
         <h1 className={styles.title}>Video Downloader</h1>
         <p className={styles.subtitle}>Create your account</p>
       </div>
-      <div className={styles.signupFormBody}>
+      <form className={styles.signupFormBody} onSubmit={onSubmit} noValidate>
         <div className={styles.nameRow}>
           <TextField
             error={errors.firstName != null}
@@ -113,6 +117,8 @@ const SignupForm: FC<SignupFormProps> = props => {
             onChange={onChange(setFirstName)}
             label="First Name"
             helperText={errors.firstName}
+            name="firstName"
+            autoComplete="given-name"
             className={styles.textField}
             fullWidth
           />
@@ -122,6 +128,8 @@ const SignupForm: FC<SignupFormProps> = props => {
             onChange={onChange(setLastName)}
             label="Last Name"
             helperText={errors.lastName}
+            name="lastName"
+            autoComplete="family-name"
             className={styles.textField}
             fullWidth
           />
@@ -133,6 +141,8 @@ const SignupForm: FC<SignupFormProps> = props => {
           label="Email"
           helperText={errors.email}
           type="email"
+          name="email"
+          autoComplete="email"
           className={styles.textField}
           fullWidth
         />
@@ -143,6 +153,8 @@ const SignupForm: FC<SignupFormProps> = props => {
           helperText={errors.password}
           label="Password"
           type={showPassword ? "text" : "password"}
+          name="password"
+          autoComplete="new-password"
           className={styles.textField}
           fullWidth
           slotProps={{
@@ -168,6 +180,8 @@ const SignupForm: FC<SignupFormProps> = props => {
           helperText={errors.confirmPassword}
           label="Confirm Password"
           type={showConfirmPassword ? "text" : "password"}
+          name="confirmPassword"
+          autoComplete="new-password"
           className={styles.textField}
           fullWidth
           slotProps={{
@@ -188,7 +202,7 @@ const SignupForm: FC<SignupFormProps> = props => {
         />
         <div className={styles.signupButton}>
           <Button
-            onClick={onSignupClick}
+            type="submit"
             variant="contained"
             color="primary"
             disabled={isSubmitting}
@@ -196,7 +210,7 @@ const SignupForm: FC<SignupFormProps> = props => {
             {isSubmitting ? "Creating Account..." : "Sign Up"}
           </Button>
         </div>
-      </div>
+      </form>
       <ErrorMessages errors={errors.response} />
       <div className={styles.loginLink}>
         Already have an account? <Link to="/sign-in">Sign in</Link>

--- a/tests/components/LoginForm.test.tsx
+++ b/tests/components/LoginForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, beforeEach } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import LoginForm from "~/pages/unauthenticated/login/components/login-form/LoginForm"
 import { DateTime } from "luxon"
@@ -68,6 +68,18 @@ describe("LoginForm", () => {
       renderWithRouter(<LoginForm onAuthenticate={mockOnAuthenticate} />)
 
       expect(screen.getByLabelText("Password")).toHaveAttribute("type", "password")
+    })
+
+    test("should have name and autocomplete attributes for autofill", () => {
+      renderWithRouter(<LoginForm onAuthenticate={mockOnAuthenticate} />)
+
+      const emailInput = screen.getByLabelText(/email/i)
+      expect(emailInput).toHaveAttribute("name", "email")
+      expect(emailInput).toHaveAttribute("autocomplete", "email")
+
+      const passwordInput = screen.getByLabelText("Password")
+      expect(passwordInput).toHaveAttribute("name", "password")
+      expect(passwordInput).toHaveAttribute("autocomplete", "current-password")
     })
 
     test("should toggle password visibility when clicking visibility button", async () => {
@@ -211,6 +223,19 @@ describe("LoginForm", () => {
       })
     })
 
+    test("should submit when pressing Enter in a field", async () => {
+      const user = userEvent.setup()
+      mockLogin.mockResolvedValue(mockToken)
+      renderWithRouter(<LoginForm onAuthenticate={mockOnAuthenticate} />)
+
+      await user.type(screen.getByLabelText(/email/i), "test@example.com")
+      await user.type(screen.getByLabelText("Password"), "password123{enter}")
+
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith("test@example.com", "password123")
+      })
+    })
+
     test("should call onAuthenticate with token on success", async () => {
       const user = userEvent.setup()
       mockLogin.mockResolvedValue(mockToken)
@@ -222,6 +247,57 @@ describe("LoginForm", () => {
 
       await waitFor(() => {
         expect(mockOnAuthenticate).toHaveBeenCalledWith(mockToken)
+      })
+    })
+  })
+
+  describe("Submission Guard", () => {
+    test("should disable the login button while submitting", async () => {
+      const user = userEvent.setup()
+      mockLogin.mockImplementation(() => new Promise(() => {})) // Never resolves
+      renderWithRouter(<LoginForm onAuthenticate={mockOnAuthenticate} />)
+
+      await user.type(screen.getByLabelText(/email/i), "test@example.com")
+      await user.type(screen.getByLabelText("Password"), "password123")
+      await user.click(screen.getByRole("button", { name: /login/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /logging in/i })).toBeDisabled()
+      })
+    })
+
+    test("should only call login once when clicked twice while in flight", async () => {
+      const user = userEvent.setup()
+      mockLogin.mockImplementation(() => new Promise(() => {})) // Never resolves
+      renderWithRouter(<LoginForm onAuthenticate={mockOnAuthenticate} />)
+
+      await user.type(screen.getByLabelText(/email/i), "test@example.com")
+      await user.type(screen.getByLabelText("Password"), "password123")
+
+      const loginButton = screen.getByRole("button", { name: /login/i })
+      await user.click(loginButton)
+
+      await waitFor(() => {
+        expect(loginButton).toBeDisabled()
+      })
+
+      // Force a second click even though the button is disabled
+      fireEvent.click(loginButton)
+
+      expect(mockLogin).toHaveBeenCalledTimes(1)
+    })
+
+    test("should re-enable the login button after a failure", async () => {
+      const user = userEvent.setup()
+      mockLogin.mockRejectedValue({ response: { status: 401 } })
+      renderWithRouter(<LoginForm onAuthenticate={mockOnAuthenticate} />)
+
+      await user.type(screen.getByLabelText(/email/i), "test@example.com")
+      await user.type(screen.getByLabelText("Password"), "wrongpassword")
+      await user.click(screen.getByRole("button", { name: /login/i }))
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /login/i })).toBeEnabled()
       })
     })
   })

--- a/tests/components/SignupForm.test.tsx
+++ b/tests/components/SignupForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi, beforeEach } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import SignupForm from "~/pages/unauthenticated/signup/components/signup-form/SignupForm"
 import { MemoryRouter } from "react-router"
@@ -91,6 +91,30 @@ describe("SignupForm", () => {
       expect(screen.getByLabelText("Email")).toHaveValue("")
       expect(screen.getByLabelText("Password")).toHaveValue("")
       expect(screen.getByLabelText("Confirm Password")).toHaveValue("")
+    })
+
+    test("should have name and autocomplete attributes for autofill", () => {
+      renderWithRouter(<SignupForm onSignup={mockOnSignup} />)
+
+      const firstNameInput = screen.getByLabelText("First Name")
+      expect(firstNameInput).toHaveAttribute("name", "firstName")
+      expect(firstNameInput).toHaveAttribute("autocomplete", "given-name")
+
+      const lastNameInput = screen.getByLabelText("Last Name")
+      expect(lastNameInput).toHaveAttribute("name", "lastName")
+      expect(lastNameInput).toHaveAttribute("autocomplete", "family-name")
+
+      const emailInput = screen.getByLabelText("Email")
+      expect(emailInput).toHaveAttribute("name", "email")
+      expect(emailInput).toHaveAttribute("autocomplete", "email")
+
+      const passwordInput = screen.getByLabelText("Password")
+      expect(passwordInput).toHaveAttribute("name", "password")
+      expect(passwordInput).toHaveAttribute("autocomplete", "new-password")
+
+      const confirmPasswordInput = screen.getByLabelText("Confirm Password")
+      expect(confirmPasswordInput).toHaveAttribute("name", "confirmPassword")
+      expect(confirmPasswordInput).toHaveAttribute("autocomplete", "new-password")
     })
 
     test("should render link to sign in page", () => {
@@ -345,6 +369,52 @@ describe("SignupForm", () => {
       await waitFor(() => {
         expect(mockOnSignup).toHaveBeenCalled()
       })
+    })
+
+    test("should submit when pressing Enter in a field", async () => {
+      const user = userEvent.setup()
+      mockCreateUser.mockResolvedValue(mockUser)
+      mockLogin.mockResolvedValue(mockToken)
+      renderWithRouter(<SignupForm onSignup={mockOnSignup} />)
+
+      await user.type(screen.getByLabelText("First Name"), "John")
+      await user.type(screen.getByLabelText("Last Name"), "Doe")
+      await user.type(screen.getByLabelText("Email"), "john@example.com")
+      await user.type(screen.getByLabelText("Password"), "password123")
+      await user.type(screen.getByLabelText("Confirm Password"), "password123{enter}")
+
+      await waitFor(() => {
+        expect(mockCreateUser).toHaveBeenCalledWith({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.com",
+          password: "password123",
+        })
+      })
+    })
+
+    test("should only call createUser once when clicked twice while in flight", async () => {
+      const user = userEvent.setup()
+      mockCreateUser.mockImplementation(() => new Promise(() => {})) // Never resolves
+      renderWithRouter(<SignupForm onSignup={mockOnSignup} />)
+
+      await user.type(screen.getByLabelText("First Name"), "John")
+      await user.type(screen.getByLabelText("Last Name"), "Doe")
+      await user.type(screen.getByLabelText("Email"), "john@example.com")
+      await user.type(screen.getByLabelText("Password"), "password123")
+      await user.type(screen.getByLabelText("Confirm Password"), "password123")
+
+      const signupButton = screen.getByRole("button", { name: /sign up/i })
+      await user.click(signupButton)
+
+      await waitFor(() => {
+        expect(signupButton).toBeDisabled()
+      })
+
+      // Force a second click even though the button is disabled
+      fireEvent.click(signupButton)
+
+      expect(mockCreateUser).toHaveBeenCalledTimes(1)
     })
 
     test("should show loading state during submission", async () => {


### PR DESCRIPTION
The login and signup forms were plain divs with click handlers, so pressing Enter did nothing and password managers could not reliably autofill the fields. This wraps both forms in a real <form> with submit buttons, adds name/autoComplete attributes to every field, and gives LoginForm the same isSubmitting guard SignupForm already had to prevent double submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)