### PR TITLE
Key video lists by stable video id instead of array index

### DIFF
--- a/app/pages/authenticated/history/HistoryPage.tsx
+++ b/app/pages/authenticated/history/HistoryPage.tsx
@@ -45,8 +45,8 @@ const HistoryPage = () => {
       >
         {
           videoWatchHistories.map(
-            (videoWatchHistory, index) =>
-              <div key={index} className={styles.videoHistoryCard}>
+            (videoWatchHistory) =>
+              <div key={videoWatchHistory.video.videoMetadata.id} className={styles.videoHistoryCard}>
                   <Link to={`/video/${videoWatchHistory.video.videoMetadata.id}`}>
                     <VideoCard video={videoWatchHistory.video} lastWatched={videoWatchHistory.lastUpdatedAt}/>
                   </Link>

--- a/app/pages/authenticated/videos/Videos.tsx
+++ b/app/pages/authenticated/videos/Videos.tsx
@@ -87,8 +87,8 @@ const Videos = () => {
         className={styles.videosList}>
         {
           videos.map(
-              (video, index) =>
-                <div key={index} className={styles.videoCard}>
+              (video) =>
+                <div key={video.videoMetadata.id} className={styles.videoCard}>
                     <Link to={`/video/${video.videoMetadata.id}`}>
                       <VideoCard video={video}/>
                     </Link>


### PR DESCRIPTION
Replaces array-index keys with the stable video id (`video.videoMetadata.id`) in the Videos and History pages, matching the pattern already used in Duplicates and Playlists. Index keys caused React to reuse component instances for different videos after a search reset, so stateful children like VideoMetadataCard displayed the previous video's snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)