### PR TITLE
Handle scheduling failures on the Schedule page

### DIFF
--- a/app/pages/authenticated/schedule/Schedule.tsx
+++ b/app/pages/authenticated/schedule/Schedule.tsx
@@ -3,19 +3,32 @@ import {Button, LinearProgress, TextField} from "@mui/material"
 import {scheduleVideo} from "~/services/scheduling/SchedulingService"
 import Helmet from "~/components/helmet/Helmet"
 import Preview from "~/components/schedule/preview/Preview"
+import ErrorMessages from "~/components/error-messages/ErrorMessages"
+import {extractErrorMessages} from "~/pages/unauthenticated/AuthFormHelpers"
 import styles from "./Schedule.module.scss"
 
 const Schedule = () => {
   const [videoUrl, setVideoUrl] = useState("")
   const [isScheduling, setScheduling] = useState(false)
+  const [errors, setErrors] = useState<string[]>([])
 
-  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => setVideoUrl(event.target.value)
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setErrors([])
+    setVideoUrl(event.target.value)
+  }
 
   const onScheduleButtonClick = async () => {
     setScheduling(true)
-    await scheduleVideo(videoUrl)
-    setVideoUrl("")
-    setScheduling(false)
+    setErrors([])
+
+    try {
+      await scheduleVideo(videoUrl)
+      setVideoUrl("")
+    } catch (error: unknown) {
+      setErrors(extractErrorMessages(error))
+    } finally {
+      setScheduling(false)
+    }
   }
 
   return (
@@ -23,10 +36,17 @@ const Schedule = () => {
       <Helmet title="Schedule"/>
       <div className={styles.schedule}>
         <TextField onChange={handleTextChange} value={videoUrl} label="Website URL" className={styles.inputUrl} />
-        <Button onClick={onScheduleButtonClick} variant="contained" color="primary" className={styles.scheduleButton}>
+        <Button
+          onClick={onScheduleButtonClick}
+          disabled={isScheduling}
+          variant="contained"
+          color="primary"
+          className={styles.scheduleButton}
+        >
           Schedule Download
         </Button>
         {isScheduling && <LinearProgress className={styles.schedulingProgress} />}
+        <ErrorMessages errors={errors} title="Scheduling failed" />
         <Preview url={videoUrl} />
       </div>
     </div>

--- a/tests/pages/Schedule.test.tsx
+++ b/tests/pages/Schedule.test.tsx
@@ -119,4 +119,67 @@ describe("Schedule", () => {
       expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
     })
   })
+
+  test("should disable the schedule button while scheduling is in flight", async () => {
+    const { scheduleVideo } = await import("~/services/scheduling/SchedulingService")
+    let resolveSchedule: () => void
+    vi.mocked(scheduleVideo).mockImplementation(() => new Promise(resolve => {
+      resolveSchedule = () => resolve(createMockScheduledVideoDownload())
+    }))
+
+    render(<Schedule />)
+
+    fireEvent.change(screen.getByLabelText("Website URL"), { target: { value: "https://example.com/video" } })
+
+    const button = screen.getByRole("button", { name: "Schedule Download" })
+    fireEvent.click(button)
+
+    expect(button).toBeDisabled()
+
+    resolveSchedule!()
+
+    await waitFor(() => {
+      expect(button).toBeEnabled()
+    })
+  })
+
+  test("should hide progress bar, show an error and keep the URL when scheduling fails", async () => {
+    const { scheduleVideo } = await import("~/services/scheduling/SchedulingService")
+    vi.mocked(scheduleVideo).mockRejectedValue(new Error("Unable to schedule video"))
+
+    render(<Schedule />)
+
+    const input = screen.getByLabelText("Website URL")
+    fireEvent.change(input, { target: { value: "https://example.com/video" } })
+
+    fireEvent.click(screen.getByRole("button", { name: "Schedule Download" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduling failed")).toBeInTheDocument()
+    })
+
+    expect(screen.getByText("Unable to schedule video")).toBeInTheDocument()
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+    expect(input).toHaveValue("https://example.com/video")
+    expect(screen.getByRole("button", { name: "Schedule Download" })).toBeEnabled()
+  })
+
+  test("should clear the error when the URL is edited", async () => {
+    const { scheduleVideo } = await import("~/services/scheduling/SchedulingService")
+    vi.mocked(scheduleVideo).mockRejectedValue(new Error("Unable to schedule video"))
+
+    render(<Schedule />)
+
+    const input = screen.getByLabelText("Website URL")
+    fireEvent.change(input, { target: { value: "https://example.com/video" } })
+    fireEvent.click(screen.getByRole("button", { name: "Schedule Download" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduling failed")).toBeInTheDocument()
+    })
+
+    fireEvent.change(input, { target: { value: "https://example.com/other-video" } })
+
+    expect(screen.queryByText("Scheduling failed")).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
A rejected scheduleVideo call previously left the LinearProgress stuck forever with no user-visible error, and the button allowed duplicate submissions while a request was in flight. The schedule action now resets the progress state in a finally block, surfaces failures via ErrorMessages, disables the button while scheduling, and only clears the URL field on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)