### PR TITLE
Fix loading races and error handling on VideoPage

### DIFF
--- a/app/pages/authenticated/videos/video-page/VideoPage.tsx
+++ b/app/pages/authenticated/videos/video-page/VideoPage.tsx
@@ -14,6 +14,7 @@ const VideoPage = (props: Route.ComponentProps) => {
   const videoId = props.params.videoId
   const [video, setVideo] = useState<Option<Video>>(None.of())
   const [videoSnapshots, setVideoSnapshots] = useState<Snapshot[]>([])
+  const [hasError, setHasError] = useState(false)
 
   const timestamp: Duration = Duration.fromObject({
     seconds: Option.fromNullable(queryParams.get("timestamp"))
@@ -21,20 +22,52 @@ const VideoPage = (props: Route.ComponentProps) => {
       .getOrElse(() => 0)
   })
 
-  const fetchVideo = async () => {
-    const video = await fetchVideoById(videoId)
-    setVideo(Some.of(video))
-  }
-
-  const fetchVideoSnapshots = async () => {
-    const snapshots = await fetchVideoSnapshotsByVideoId(videoId)
-    setVideoSnapshots(snapshots)
-  }
-
   useEffect(() => {
+    let cancelled = false
+
+    setVideo(None.of())
+    setVideoSnapshots([])
+    setHasError(false)
+
+    const fetchVideo = async () => {
+      try {
+        const video = await fetchVideoById(videoId)
+
+        if (!cancelled) {
+          setVideo(Some.of(video))
+        }
+      } catch {
+        if (!cancelled) {
+          setHasError(true)
+        }
+      }
+    }
+
+    const fetchVideoSnapshots = async () => {
+      try {
+        const snapshots = await fetchVideoSnapshotsByVideoId(videoId)
+
+        if (!cancelled) {
+          setVideoSnapshots(snapshots)
+        }
+      } catch {
+        if (!cancelled) {
+          setHasError(true)
+        }
+      }
+    }
+
     fetchVideo()
     fetchVideoSnapshots()
+
+    return () => {
+      cancelled = true
+    }
   }, [videoId])
+
+  if (hasError) {
+    return <div>Unable to load video</div>
+  }
 
   return (
     <LoadableComponent>

--- a/tests/pages/VideoPage.test.tsx
+++ b/tests/pages/VideoPage.test.tsx
@@ -97,6 +97,68 @@ describe("VideoPage", () => {
     expect(screen.getByTestId("snapshot-count")).toHaveTextContent("2")
   })
 
+  test("shows an error message instead of the spinner when the video fetch fails", async () => {
+    mockFetchVideoById.mockRejectedValue(new Error("not found"))
+
+    renderVideoPage("missing-video", "/video/missing-video")
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to load video")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("video-watch")).not.toBeInTheDocument()
+  })
+
+  test("shows an error message when the snapshots fetch fails", async () => {
+    mockFetchVideoById.mockResolvedValue(buildVideo("video-123", "My Video"))
+    mockFetchVideoSnapshots.mockRejectedValue(new Error("snapshots failed"))
+
+    renderVideoPage("video-123", "/video/video-123")
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to load video")).toBeInTheDocument()
+    })
+  })
+
+  test("resets and shows fresh data when the videoId changes", async () => {
+    mockFetchVideoById.mockResolvedValue(buildVideo("video-a", "Video A"))
+
+    const { rerender } = renderVideoPage("video-a", "/video/video-a")
+
+    await waitFor(() => {
+      expect(screen.getByTestId("title")).toHaveTextContent("Video A")
+    })
+
+    // Navigate to video B while its fetch is still pending: the page must drop
+    // video A and show the loading indicator again.
+    let resolveVideoB: (video: ReturnType<typeof buildVideo>) => void
+    mockFetchVideoById.mockReturnValue(
+      new Promise((resolve) => {
+        resolveVideoB = resolve
+      })
+    )
+
+    rerender(
+      <MemoryRouter initialEntries={["/video/video-b"]}>
+        <VideoPage {...({ params: { videoId: "video-b" } } as any)} />
+      </MemoryRouter>
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("video-watch")).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole("progressbar")).toBeInTheDocument()
+
+    resolveVideoB!(buildVideo("video-b", "Video B"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("title")).toHaveTextContent("Video B")
+    })
+    expect(mockFetchVideoById).toHaveBeenLastCalledWith("video-b")
+    expect(mockFetchVideoSnapshots).toHaveBeenLastCalledWith("video-b")
+  })
+
   test("parses the timestamp query parameter", async () => {
     mockFetchVideoById.mockResolvedValue(buildVideo("video-123", "My Video"))
 


### PR DESCRIPTION
VideoPage's fetch effect fired two floating promises with no error handling, no state reset, and no cancellation, so a bad video id left the spinner forever and rapid navigation could show video A's data on video B's URL. The effect now resets state when the videoId changes, drops stale resolutions via a cancelled flag, and shows a short error message instead of an eternal spinner when a fetch fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)