### PR TITLE
Fetch backend service info once instead of polling every 500ms

### DIFF
--- a/app/pages/authenticated/service-information/ServiceInformation.tsx
+++ b/app/pages/authenticated/service-information/ServiceInformation.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type ReactNode, useEffect, useState } from "react"
+import React, { type FC, type ReactNode, useEffect, useRef, useState } from "react"
 import {
   frontendServiceInformation,
   performHealthCheck,
@@ -22,7 +22,7 @@ import VideoLibraryIcon from "@mui/icons-material/VideoLibrary"
 import FolderIcon from "@mui/icons-material/Folder"
 import { None, type Option, Some } from "~/types/Option"
 import Helmet from "~/components/helmet/Helmet"
-import { DateTime } from "luxon"
+import { DateTime, Duration } from "luxon"
 
 import styles from "./ServiceInformation.module.scss"
 import {
@@ -58,11 +58,19 @@ type CopyableTextProps = {
 
 const CopyableText: FC<CopyableTextProps> = ({ text }) => {
   const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => () => clearTimeout(timeoutRef.current), [])
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+    } catch (error) {
+      console.error("Failed to copy to clipboard", error)
+    }
   }
 
   return (
@@ -217,9 +225,11 @@ const ServiceInformation = () => {
   const [backendInformation, setBackendInformation] = useState<Option<BackendServiceInformation>>(None.of())
   const [frontendInformation, setFrontendInformation] = useState(frontendServiceInformation(import.meta.env))
   const [healthCheckDetails, setHealthCheckDetails] = useState<Option<HealthCheckDetails>>(None.of())
+  const serverTimeOffset = useRef<Duration<boolean>>(Duration.fromMillis(0))
 
   const fetchBackendInformation = async () => {
     const information = await retrieveBackendServiceInformation()
+    serverTimeOffset.current = information.currentTimestamp.diff(DateTime.now())
     setBackendInformation(Some.of(information))
   }
 
@@ -240,7 +250,21 @@ const ServiceInformation = () => {
 
   useEffect(() => {
     fetchBackendInformation()
-    const intervalId = setInterval(fetchBackendInformation, 500)
+      .catch((error) => console.error("Failed to retrieve backend service information", error))
+  }, [])
+
+  useEffect(() => {
+    const intervalId =
+      setInterval(
+        () =>
+          setBackendInformation((backendInformation) =>
+            backendInformation.map((information) => ({
+              ...information,
+              currentTimestamp: DateTime.now().plus(serverTimeOffset.current)
+            }))
+          ),
+        1000
+      )
 
     return () => clearInterval(intervalId)
   }, [])

--- a/tests/pages/ServiceInformation.test.tsx
+++ b/tests/pages/ServiceInformation.test.tsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import ServiceInformation from "~/pages/authenticated/service-information/ServiceInformation"
 import { createMemoryRouter, RouterProvider } from "react-router"
 import { DateTime, Duration } from "luxon"
@@ -115,6 +115,10 @@ describe("ServiceInformation", () => {
     vi.mocked(retrieveBackendServiceInformation).mockResolvedValue(createMockBackendInfo())
     vi.mocked(performHealthCheck).mockResolvedValue(createMockHealthCheck())
     vi.mocked(frontendServiceInformation).mockReturnValue(createMockFrontendInfo())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test("should render the page with Backend and Frontend section titles", async () => {
@@ -260,14 +264,18 @@ describe("ServiceInformation", () => {
     })
   })
 
-  test("should call retrieveBackendServiceInformation on mount", async () => {
+  test("should call retrieveBackendServiceInformation only once on mount", async () => {
     const { retrieveBackendServiceInformation } = await import("~/services/health/HealthCheckService")
 
     renderWithRouter()
 
     await waitFor(() => {
-      expect(retrieveBackendServiceInformation).toHaveBeenCalled()
+      expect(retrieveBackendServiceInformation).toHaveBeenCalledTimes(1)
     })
+
+    await act(() => vi.advanceTimersByTimeAsync(5000))
+
+    expect(retrieveBackendServiceInformation).toHaveBeenCalledTimes(1)
   })
 
   test("should call performHealthCheck on mount", async () => {


### PR DESCRIPTION
The Service Information page was hitting the backend-info endpoint every 500ms with no overlap protection or error handling, even though the data is static apart from the server timestamp. It now fetches once on mount and advances the displayed server timestamp locally with a 1s interval using the recorded server/local time offset, and CopyableText now clears its timeout on unmount and catches clipboard failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)