### PR TITLE
Fix stale-response race and unhandled rejection in schedule Preview

### DIFF
--- a/app/components/schedule/preview/Preview.tsx
+++ b/app/components/schedule/preview/Preview.tsx
@@ -1,4 +1,5 @@
 import React, {type FC, useEffect, useState} from "react"
+import {Typography} from "@mui/material"
 import {LoadableComponent} from "~/components/hoc/loading/LoadableComponent"
 import VideoMetadataCard from "~/components/video/video-metadata-card/VideoMetadataCard"
 import {type VideoMetadata} from "~/models/VideoMetadata"
@@ -11,32 +12,52 @@ type PreviewProps = {
 
 const Preview: FC<PreviewProps> = props => {
   const [maybeVideoMetadata, setMaybeVideoMetadata] = useState<Option<VideoMetadata>>(None.of())
+  const [hasError, setHasError] = useState(false)
 
   const isEmptyUrl = props.url.trim().length === 0
 
   useEffect(() => {
+    let cancelled = false
+
     const timeoutId = setTimeout(() => {
       if (!isEmptyUrl) {
-        metadata(props.url).then((result) => setMaybeVideoMetadata(Option.fromNullable(result)))
+        metadata(props.url)
+          .then((result) => {
+            if (!cancelled) {
+              setMaybeVideoMetadata(Option.fromNullable(result))
+            }
+          })
+          .catch(() => {
+            if (!cancelled) {
+              setHasError(true)
+            }
+          })
       }
     }, 500)
 
     setMaybeVideoMetadata(None.of())
+    setHasError(false)
 
-    return () => clearTimeout(timeoutId)
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
   }, [props.url])
 
   return (
     <div>
       {
-        !isEmptyUrl &&
-        <LoadableComponent>
-          {
-            maybeVideoMetadata.map((videoMetadata) =>
-              <VideoMetadataCard videoMetadata={videoMetadata} disableSnapshots={true}/>
-            )
-          }
-        </LoadableComponent>
+        !isEmptyUrl && (
+          hasError ?
+            <Typography color="error">Unable to load video preview</Typography> :
+            <LoadableComponent>
+              {
+                maybeVideoMetadata.map((videoMetadata) =>
+                  <VideoMetadataCard videoMetadata={videoMetadata} disableSnapshots={true}/>
+                )
+              }
+            </LoadableComponent>
+        )
       }
     </div>
   )

--- a/tests/components/Preview.test.tsx
+++ b/tests/components/Preview.test.tsx
@@ -37,7 +37,7 @@ const createMockVideoMetadata = () => ({
   },
 })
 
-const renderWithContext = (url: string) => {
+const previewWithContext = (url: string) => {
   const contextValue = {
     safeMode: false,
     theme: Theme.Light,
@@ -45,12 +45,14 @@ const renderWithContext = (url: string) => {
     setTheme: vi.fn(),
   }
 
-  return render(
+  return (
     <ApplicationConfigurationContext.Provider value={Some.of(contextValue)}>
       <Preview url={url} />
     </ApplicationConfigurationContext.Provider>
   )
 }
+
+const renderWithContext = (url: string) => render(previewWithContext(url))
 
 describe("Preview", () => {
   beforeEach(() => {
@@ -93,5 +95,54 @@ describe("Preview", () => {
 
     // Should show loading component
     expect(screen.getByRole("progressbar")).toBeInTheDocument()
+  })
+
+  test("should not overwrite the newer preview with a slow stale response", async () => {
+    let resolveStale: (value: ReturnType<typeof createMockVideoMetadata>) => void = () => {}
+    const staleMetadata = { ...createMockVideoMetadata(), title: "Old Video" }
+    const freshMetadata = { ...createMockVideoMetadata(), title: "New Video" }
+
+    mockMetadata
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveStale = resolve }))
+      .mockResolvedValueOnce(freshMetadata)
+
+    const { rerender } = renderWithContext("https://example.com/old")
+
+    // Fire the request for the old URL; its response stays pending
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    rerender(previewWithContext("https://example.com/new"))
+
+    // Fire the request for the new URL; its response resolves immediately
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(screen.getByText("New Video")).toBeInTheDocument()
+
+    // The stale response arrives late and must not overwrite the newer preview
+    await act(async () => {
+      resolveStale(staleMetadata)
+    })
+
+    expect(screen.getByText("New Video")).toBeInTheDocument()
+    expect(screen.queryByText("Old Video")).not.toBeInTheDocument()
+  })
+
+  test("should show an error state instead of the spinner when metadata fails", async () => {
+    mockMetadata.mockRejectedValue(new Error("metadata failed"))
+
+    renderWithContext("https://example.com/video")
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+    expect(screen.getByText("Unable to load video preview")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The Preview component's debounced metadata fetch could resolve after the user typed a new URL, overwriting the newer preview, and a rejected request left the loading spinner showing forever. The effect now tracks a cancelled flag in its cleanup to ignore stale resolutions, and failures render a brief inline error message instead of the spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)