### PR TITLE
Fix video delete flow in VideoWatch

### DIFF
--- a/app/pages/authenticated/videos/video-page/watch/VideoWatch.tsx
+++ b/app/pages/authenticated/videos/video-page/watch/VideoWatch.tsx
@@ -18,6 +18,7 @@ import { Duration } from "luxon"
 import { Option } from "~/types/Option"
 import { translate } from "~/services/sanitize/SanitizationService"
 import { useApplicationConfiguration } from "~/providers/ApplicationConfigurationProvider"
+import { useNavigate } from "react-router"
 
 type VideoDeleteDialogProps = {
   readonly isVisible: boolean
@@ -35,14 +36,18 @@ const VideoDeleteDialog: FC<VideoDeleteDialogProps> = props => {
       <DialogContent>
         <VideoMetadataCard videoMetadata={props.videoMetadata} />
         <div>
-          Delete video file <Checkbox value={deleteFile} onChange={(event) => setDeleteFile(event.target.checked)} />
+          Delete video file <Checkbox checked={deleteFile} onChange={(event) => setDeleteFile(event.target.checked)} />
         </div>
       </DialogContent>
       <DialogActions>
         <Button
           color="secondary"
           variant="contained"
-          onClick={() => props.onDelete(deleteFile).then(() => setDeleteFile(false))}
+          onClick={() =>
+            props.onDelete(deleteFile)
+              .then(() => setDeleteFile(false))
+              .catch((error) => console.error(error))
+          }
         >
           Delete
         </Button>
@@ -125,6 +130,7 @@ const VideoWatch: FC<VideoWatchProps> = props => {
   const [isDeleteDialogVisible, setDeleteDialogVisibility] = useState<boolean>(false)
   const [resolution, setResolution] = useState<Resolution | null>(null)
   const { safeMode } = useApplicationConfiguration()
+  const navigate = useNavigate()
 
   useEffect(() => {
     Option.fromNullable(videoPlayer.current)
@@ -151,6 +157,7 @@ const VideoWatch: FC<VideoWatchProps> = props => {
   const onDeleteVideo = async (deleteFile: boolean): Promise<void> => {
     await deleteVideo(props.video.videoMetadata.id, deleteFile)
     setDeleteDialogVisibility(false)
+    navigate("/")
   }
 
   const title = translate(props.video.videoMetadata.title, safeMode)

--- a/tests/components/VideoWatch.test.tsx
+++ b/tests/components/VideoWatch.test.tsx
@@ -8,6 +8,16 @@ import { Some } from "~/types/Option"
 import { FileResourceType } from "~/models/FileResource"
 import React from "react"
 
+const mockNavigate = vi.fn()
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router")
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
 vi.mock("~/services/asset/AssetService", () => ({
   imageUrl: vi.fn(() => "https://example.com/image.jpg"),
   videoUrl: vi.fn(() => "https://example.com/video.mp4"),
@@ -274,6 +284,68 @@ describe("VideoWatch", () => {
     await waitFor(() => {
       expect(deleteVideo).toHaveBeenCalledWith("video-123", true)
     })
+  })
+
+  test("should toggle the delete file checkbox visually", async () => {
+    renderWithContext()
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Video?")).toBeInTheDocument()
+    })
+
+    const checkbox = screen.getByRole("checkbox")
+    expect(checkbox).not.toBeChecked()
+
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+
+    fireEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+  })
+
+  test("should navigate to the videos listing after a successful delete", async () => {
+    renderWithContext()
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Video?")).toBeInTheDocument()
+    })
+
+    const dialogButtons = screen.getAllByRole("button", { name: "Delete" })
+    fireEvent.click(dialogButtons[dialogButtons.length - 1])
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/")
+    })
+  })
+
+  test("should not navigate and keep the dialog open when delete fails", async () => {
+    const { deleteVideo } = await import("~/services/video/VideoService")
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.mocked(deleteVideo).mockRejectedValueOnce(new Error("delete failed"))
+
+    renderWithContext()
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Video?")).toBeInTheDocument()
+    })
+
+    const dialogButtons = screen.getAllByRole("button", { name: "Delete" })
+    fireEvent.click(dialogButtons[dialogButtons.length - 1])
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByText("Delete Video?")).toBeInTheDocument()
+
+    consoleErrorSpy.mockRestore()
   })
 
   test("should update video title when edited", async () => {


### PR DESCRIPTION
Fixes the delete dialog in VideoWatch: the delete-file checkbox is now controlled via `checked` so it toggles and resets correctly, a successful delete navigates back to the videos listing instead of leaving the deleted video rendered, and a failed delete is caught (logged) so it no longer surfaces as an unhandled rejection while the dialog stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)