### PR TITLE
Fix stale shuffled queue on playlist add/remove

### DIFF
--- a/app/pages/authenticated/playlists/PlaylistDetail.tsx
+++ b/app/pages/authenticated/playlists/PlaylistDetail.tsx
@@ -24,7 +24,7 @@ import {
 } from "@dnd-kit/sortable"
 import { Playlist } from "~/models/Playlist"
 import { Video } from "~/models/Video"
-import { None, type Option, Some } from "~/types/Option"
+import { None, Option, Some } from "~/types/Option"
 import {
   fetchPlaylistById,
   deletePlaylist,
@@ -135,14 +135,22 @@ const PlaylistDetail = (props: Route.ComponentProps) => {
   }
 
   const handleUpdateTitle = async (title: string) => {
-    await updatePlaylist(playlistId, title)
-    setPlaylist(prev => prev.map(p => ({ ...p, title })))
+    try {
+      await updatePlaylist(playlistId, title)
+      setPlaylist(prev => prev.map(p => ({ ...p, title })))
+    } catch (error) {
+      console.error("Failed to update playlist title", error)
+    }
   }
 
   const handleDelete = async () => {
     if (window.confirm("Are you sure you want to delete this playlist?")) {
-      await deletePlaylist(playlistId)
-      navigate("/playlists")
+      try {
+        await deletePlaylist(playlistId)
+        navigate("/playlists")
+      } catch (error) {
+        console.error("Failed to delete playlist", error)
+      }
     }
   }
 
@@ -150,16 +158,32 @@ const PlaylistDetail = (props: Route.ComponentProps) => {
     const currentPlaylist = playlist.toNullable()
     if (!currentPlaylist) return
 
-    const updatedPlaylist = await removeVideoFromPlaylist(currentPlaylist, videoId)
-    setPlaylist(Some.of(updatedPlaylist))
+    try {
+      const updatedPlaylist = await removeVideoFromPlaylist(currentPlaylist, videoId)
+      setPlaylist(Some.of(updatedPlaylist))
+      if (isShuffled) {
+        setShuffledVideos(prev => prev.filter(v => v.videoMetadata.id !== videoId))
+      }
+    } catch (error) {
+      console.error("Failed to remove video from playlist", error)
+    }
   }
 
   const handleAddVideo = async (videoId: string) => {
     const currentPlaylist = playlist.toNullable()
     if (!currentPlaylist) return
 
-    const updatedPlaylist = await addVideoToPlaylist(currentPlaylist, videoId)
-    setPlaylist(Some.of(updatedPlaylist))
+    try {
+      const updatedPlaylist = await addVideoToPlaylist(currentPlaylist, videoId)
+      setPlaylist(Some.of(updatedPlaylist))
+      if (isShuffled) {
+        Option.fromNullable(
+          updatedPlaylist.videos.find(v => v.videoMetadata.id === videoId)
+        ).forEach(addedVideo => setShuffledVideos(prev => [...prev, addedVideo]))
+      }
+    } catch (error) {
+      console.error("Failed to add video to playlist", error)
+    }
   }
 
   const handleAlbumArtUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -170,6 +194,8 @@ const PlaylistDetail = (props: Route.ComponentProps) => {
     try {
       const updatedPlaylist = await uploadAlbumArt(playlistId, file)
       setPlaylist(Some.of(updatedPlaylist))
+    } catch (error) {
+      console.error("Failed to upload album art", error)
     } finally {
       setIsUploadingAlbumArt(false)
       if (fileInputRef.current) fileInputRef.current.value = ""
@@ -177,8 +203,12 @@ const PlaylistDetail = (props: Route.ComponentProps) => {
   }
 
   const handleRemoveAlbumArt = async () => {
-    const updatedPlaylist = await removeAlbumArt(playlistId)
-    setPlaylist(Some.of(updatedPlaylist))
+    try {
+      const updatedPlaylist = await removeAlbumArt(playlistId)
+      setPlaylist(Some.of(updatedPlaylist))
+    } catch (error) {
+      console.error("Failed to remove album art", error)
+    }
   }
 
   const handlePlay = () => {

--- a/tests/pages/PlaylistDetail.test.tsx
+++ b/tests/pages/PlaylistDetail.test.tsx
@@ -1006,6 +1006,151 @@ describe("PlaylistDetail", () => {
     })
   })
 
+  describe("Shuffle Staleness", () => {
+    test("should exclude a removed video from the shuffled play queue", async () => {
+      const user = userEvent.setup()
+      const playlist = createMockPlaylist(3)
+      mockFetchPlaylistById.mockResolvedValue(playlist)
+      mockRemoveVideoFromPlaylist.mockResolvedValue({
+        ...playlist,
+        videos: playlist.videos.filter(v => v.videoMetadata.id !== "video-2"),
+      })
+
+      renderWithRouter()
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument()
+      })
+
+      // Start playing and enable shuffle
+      await user.click(screen.getByRole("button", { name: /play/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText("1 / 3")).toBeInTheDocument()
+      })
+
+      const shuffleButton = screen.getByTestId("ShuffleIcon").closest("button")!
+      await user.click(shuffleButton)
+
+      // Close the player while shuffle stays enabled
+      const closeIcons = screen.getAllByTestId("CloseIcon")
+      const closeButton = closeIcons[closeIcons.length - 1].closest("button")!
+      await user.click(closeButton)
+
+      await waitFor(() => {
+        expect(screen.queryByText("1 / 3")).not.toBeInTheDocument()
+      })
+
+      // Remove Video 2 (first delete icon is in the header, then one per video card)
+      const deleteIcons = screen.getAllByTestId("DeleteIcon")
+      const videoDeleteButton = deleteIcons[2].closest("button")!
+      await user.click(videoDeleteButton)
+
+      await waitFor(() => {
+        expect(mockRemoveVideoFromPlaylist).toHaveBeenCalled()
+      })
+
+      // Replaying while shuffled should use a queue without the removed video
+      await user.click(screen.getByRole("button", { name: /play/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText("1 / 2")).toBeInTheDocument()
+      })
+
+      expect(screen.queryByText("Video 2")).not.toBeInTheDocument()
+    })
+
+    test("should include a newly added video in the shuffled play queue", async () => {
+      const user = userEvent.setup()
+      const playlist = createMockPlaylist(2)
+      mockFetchPlaylistById.mockResolvedValue(playlist)
+      mockSearchVideos.mockResolvedValue({
+        results: [createMockVideo("new-video", "New Video")],
+        pageNumber: 0,
+        pageSize: 50,
+        searchTerm: None.of(),
+      })
+      mockAddVideoToPlaylist.mockResolvedValue({
+        ...playlist,
+        videos: [...playlist.videos, createMockVideo("new-video", "New Video")],
+      })
+
+      renderWithRouter()
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument()
+      })
+
+      // Start playing and enable shuffle
+      await user.click(screen.getByRole("button", { name: /play/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText("1 / 2")).toBeInTheDocument()
+      })
+
+      const shuffleButton = screen.getByTestId("ShuffleIcon").closest("button")!
+      await user.click(shuffleButton)
+
+      // Close the player while shuffle stays enabled
+      const closeIcons = screen.getAllByTestId("CloseIcon")
+      const closeButton = closeIcons[closeIcons.length - 1].closest("button")!
+      await user.click(closeButton)
+
+      await waitFor(() => {
+        expect(screen.queryByText("1 / 2")).not.toBeInTheDocument()
+      })
+
+      // Add a new video via the search panel
+      await user.click(screen.getByRole("button", { name: /add videos/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText("New Video")).toBeInTheDocument()
+      })
+
+      const addButton = screen.getByTestId("AddIcon").closest("button")!
+      await user.click(addButton)
+
+      await waitFor(() => {
+        expect(mockAddVideoToPlaylist).toHaveBeenCalled()
+      })
+
+      // Replaying while shuffled should include the newly added video in the queue
+      await user.click(screen.getByRole("button", { name: /^play$/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText("1 / 3")).toBeInTheDocument()
+      })
+    })
+
+    test("should keep the video when removal fails on the server", async () => {
+      const user = userEvent.setup()
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      mockFetchPlaylistById.mockResolvedValue(createMockPlaylist(2))
+      mockRemoveVideoFromPlaylist.mockRejectedValue(new Error("Remove failed"))
+
+      renderWithRouter()
+
+      await waitFor(() => {
+        expect(screen.getByText("Video 1")).toBeInTheDocument()
+      })
+
+      const deleteIcons = screen.getAllByTestId("DeleteIcon")
+      const videoDeleteButton = deleteIcons[1].closest("button")!
+      await user.click(videoDeleteButton)
+
+      await waitFor(() => {
+        expect(mockRemoveVideoFromPlaylist).toHaveBeenCalled()
+      })
+
+      // The video should still be displayed since the server call failed
+      expect(screen.getByText("Video 1")).toBeInTheDocument()
+      expect(screen.getByText("2 videos")).toBeInTheDocument()
+      expect(consoleErrorSpy).toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+  })
+
   describe("Player ends at last video", () => {
     test("should close player when reaching end of playlist", async () => {
       const user = userEvent.setup()


### PR DESCRIPTION
While shuffle was active, removing or adding a playlist video only updated the playlist state, so the shuffled play queue kept deleted videos and never picked up new ones. The handlers now keep shuffledVideos in sync, and the page's async handlers catch server failures instead of silently leaving unhandled rejections and inconsistent UI state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)