### PR TITLE
Use axios params objects instead of manual query-string concatenation

### DIFF
--- a/app/services/history/HistoryService.ts
+++ b/app/services/history/HistoryService.ts
@@ -4,7 +4,12 @@ import { ListResponse } from "~/models/ListResponse"
 import { zodParse } from "~/types/Zod"
 
 export const getVideoHistory = async (pageNumber: number, pageSize: number): Promise<VideoWatchHistory[]> => {
-  const response = await axiosClient.get(`/videos/history?page-number=${pageNumber}&page-size=${pageSize}`)
+  const response = await axiosClient.get("/videos/history", {
+    params: {
+      "page-number": pageNumber,
+      "page-size": pageSize,
+    },
+  })
   const history = zodParse(ListResponse(VideoWatchHistory), response.data).results
 
   return history

--- a/app/services/scheduling/SchedulingService.ts
+++ b/app/services/scheduling/SchedulingService.ts
@@ -86,27 +86,23 @@ export const fetchScheduledVideos = async (
   sortBy: SortBy,
   ordering: Ordering
 ): Promise<ScheduledVideoDownload[]> => {
-  const response = await axiosClient
-    .get(
-      "/schedule/search?",
-      {
-        params: {
-          status: `${[
-            SchedulingStatus.Active,
-            SchedulingStatus.Error,
-            SchedulingStatus.Queued,
-            SchedulingStatus.Stale,
-            SchedulingStatus.Paused,
-            SchedulingStatus.WorkersPaused,
-          ].join(",")}`,
-          "page-number": pageNumber,
-          "page-size": pageSize,
-          "sort-by": sortBy,
-          order: ordering,
-          "search-term": searchTerm.getOrElse(() => ""),
-        }
-      }
-    )
+  const response = await axiosClient.get("/schedule/search", {
+    params: {
+      status: [
+        SchedulingStatus.Active,
+        SchedulingStatus.Error,
+        SchedulingStatus.Queued,
+        SchedulingStatus.Stale,
+        SchedulingStatus.Paused,
+        SchedulingStatus.WorkersPaused,
+      ].join(","),
+      "page-number": pageNumber,
+      "page-size": pageSize,
+      "sort-by": sortBy,
+      order: ordering,
+      "search-term": searchTerm.toNullable(),
+    },
+  })
 
   const scheduledVideoDownloads = zodParse(ListResponse(ScheduledVideoDownload), response.data).results
 

--- a/app/services/video/VideoService.ts
+++ b/app/services/video/VideoService.ts
@@ -81,14 +81,23 @@ export const videoServiceSummary = async (): Promise<VideoServiceSummary> => {
 }
 
 export const deleteVideo = async (videoId: string, deleteFile: boolean): Promise<Video> => {
-  const response = await axiosClient.delete(`/videos/id/${videoId}?delete-video-file=${deleteFile}`)
+  const response = await axiosClient.delete(`/videos/id/${videoId}`, {
+    params: {
+      "delete-video-file": deleteFile,
+    },
+  })
   const video = zodParse(Video, response.data)
 
   return video
 }
 
 export const fetchDuplicateVideos = async (pageNumber: number, pageSize: number): Promise<DuplicateVideoGroups> => {
-  const response = await axiosClient.get(`/videos/duplicates?page-number=${pageNumber}&page-size=${pageSize}`)
+  const response = await axiosClient.get("/videos/duplicates", {
+    params: {
+      "page-number": pageNumber,
+      "page-size": pageSize,
+    },
+  })
   return zodParse(DuplicateVideoGroups, response.data)
 }
 

--- a/tests/services/HistoryService.test.ts
+++ b/tests/services/HistoryService.test.ts
@@ -67,7 +67,12 @@ describe("HistoryService", () => {
 
       await getVideoHistory(0, 20)
 
-      expect(mockAxiosGet).toHaveBeenCalledWith("/videos/history?page-number=0&page-size=20")
+      expect(mockAxiosGet).toHaveBeenCalledWith("/videos/history", {
+        params: {
+          "page-number": 0,
+          "page-size": 20,
+        },
+      })
     })
 
     test("should return parsed video watch history", async () => {
@@ -109,7 +114,12 @@ describe("HistoryService", () => {
 
       await getVideoHistory(5, 50)
 
-      expect(mockAxiosGet).toHaveBeenCalledWith("/videos/history?page-number=5&page-size=50")
+      expect(mockAxiosGet).toHaveBeenCalledWith("/videos/history", {
+        params: {
+          "page-number": 5,
+          "page-size": 50,
+        },
+      })
     })
   })
 })

--- a/tests/services/SchedulingService.test.ts
+++ b/tests/services/SchedulingService.test.ts
@@ -224,7 +224,7 @@ describe("SchedulingService", () => {
         Ordering.Descending
       )
 
-      expect(mockAxiosGet).toHaveBeenCalledWith("/schedule/search?", {
+      expect(mockAxiosGet).toHaveBeenCalledWith("/schedule/search", {
         params: expect.objectContaining({
           "page-number": 0,
           "page-size": 20,
@@ -236,7 +236,7 @@ describe("SchedulingService", () => {
       expect(result).toHaveLength(1)
     })
 
-    test("should fetch with empty search term when None", async () => {
+    test("should send null search term when None so axios omits the param", async () => {
       mockAxiosGet.mockResolvedValue({ data: { results: [] } })
 
       await fetchScheduledVideos(
@@ -247,9 +247,9 @@ describe("SchedulingService", () => {
         Ordering.Ascending
       )
 
-      expect(mockAxiosGet).toHaveBeenCalledWith("/schedule/search?", {
+      expect(mockAxiosGet).toHaveBeenCalledWith("/schedule/search", {
         params: expect.objectContaining({
-          "search-term": "",
+          "search-term": null,
         }),
       })
     })

--- a/tests/services/VideoService.test.ts
+++ b/tests/services/VideoService.test.ts
@@ -23,6 +23,7 @@ import {
   updateVideoTitle,
   videoServiceSummary,
   deleteVideo,
+  fetchDuplicateVideos,
   scanForVideos,
   fetchVideoScanStatus,
 } from "~/services/video/VideoService"
@@ -267,7 +268,11 @@ describe("VideoService", () => {
 
       const result = await deleteVideo("video-123", false)
 
-      expect(mockAxiosDelete).toHaveBeenCalledWith("/videos/id/video-123?delete-video-file=false")
+      expect(mockAxiosDelete).toHaveBeenCalledWith("/videos/id/video-123", {
+        params: {
+          "delete-video-file": false,
+        },
+      })
       expect(result.videoMetadata.id).toBe("video-123")
     })
 
@@ -276,7 +281,37 @@ describe("VideoService", () => {
 
       await deleteVideo("video-123", true)
 
-      expect(mockAxiosDelete).toHaveBeenCalledWith("/videos/id/video-123?delete-video-file=true")
+      expect(mockAxiosDelete).toHaveBeenCalledWith("/videos/id/video-123", {
+        params: {
+          "delete-video-file": true,
+        },
+      })
+    })
+  })
+
+  describe("fetchDuplicateVideos", () => {
+    test("should call API with pagination params and return parsed groups", async () => {
+      const mockGroups = {
+        "group-1": [
+          {
+            videoId: "video-123",
+            duplicateGroupId: "group-1",
+            createdAt: "2024-01-15T10:00:00+00:00",
+          },
+        ],
+      }
+      mockAxiosGet.mockResolvedValue({ data: mockGroups })
+
+      const result = await fetchDuplicateVideos(2, 25)
+
+      expect(mockAxiosGet).toHaveBeenCalledWith("/videos/duplicates", {
+        params: {
+          "page-number": 2,
+          "page-size": 25,
+        },
+      })
+      expect(result["group-1"]).toHaveLength(1)
+      expect(result["group-1"][0].videoId).toBe("video-123")
     })
   })
 


### PR DESCRIPTION
Converts the history, video, and scheduling services to pass axios `{ params }` objects instead of concatenating query strings, per the project convention. Also removes the stray `?` from `/schedule/search` (which produced `?&status=...`) and omits `search-term` when the search term is None instead of sending an empty value. Service tests updated to match, with a new test covering `fetchDuplicateVideos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)