### PR TITLE
Handle async action and fetch errors in UI components

### DIFF
--- a/app/components/quick-settings/switches/WorkerStatusSwitch.tsx
+++ b/app/components/quick-settings/switches/WorkerStatusSwitch.tsx
@@ -8,7 +8,7 @@ const WorkerStatusSwitch = () => {
   const [workerStatus, setWorkerStatus] = useState<WorkerStatus | null>(null)
 
   useEffect(() => {
-    fetchWorkerStatus().then((status) => setWorkerStatus(status))
+    fetchWorkerStatus().then((status) => setWorkerStatus(status)).catch(console.error)
   }, [])
 
   const onClick = async () => {

--- a/app/components/scan/VideoScanButton.tsx
+++ b/app/components/scan/VideoScanButton.tsx
@@ -29,12 +29,21 @@ const VideoScanButton: FC<VideoScanButtonProps> = props => {
 
   const onClick = async () => {
     setScanStatus(Some.of(ScanStatus.InProgress))
-    await scanForVideos()
+
+    try {
+      await scanForVideos()
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   const retrieveScanStatus = async () => {
-    const videoScan: VideoScan = await fetchVideoScanStatus()
-    setScanStatus(Some.of(videoScan.scanStatus))
+    try {
+      const videoScan: VideoScan = await fetchVideoScanStatus()
+      setScanStatus(Some.of(videoScan.scanStatus))
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   const label = isScanInProgress ? "Scanning..." : "Scan For Videos"

--- a/app/pages/authenticated/downloading/ScheduledVideos.tsx
+++ b/app/pages/authenticated/downloading/ScheduledVideos.tsx
@@ -114,6 +114,8 @@ const ScheduledVideos = () => {
 
     try {
       await retryFailedScheduledVideos()
+    } catch (error) {
+      console.error(error)
     } finally {
       setDisableRetry(false)
     }

--- a/app/pages/authenticated/downloading/scheduled-video-download-card/ScheduledVideoDownloadCard.tsx
+++ b/app/pages/authenticated/downloading/scheduled-video-download-card/ScheduledVideoDownloadCard.tsx
@@ -87,7 +87,7 @@ const ErrorDetailsDialog: FC<ErrorDetailsDialogProps> = props => (
       {props.scheduleVideoDownload.errorInfo?.message}
     </DialogContent>
     <DialogActions>
-      <Button onClick={() => props.onUpdateStatus(SchedulingStatus.Queued).finally(props.onClose)}>Retry</Button>
+      <Button onClick={() => props.onUpdateStatus(SchedulingStatus.Queued).catch(console.error).finally(props.onClose)}>Retry</Button>
       <Button onClick={props.onClose}>Cancel</Button>
     </DialogActions>
   </Dialog>
@@ -110,7 +110,7 @@ const ScheduledVideoDeleteDialog: FC<ScheduledVideoDeleteDialogProps> = props =>
       <Button
         color="secondary"
         variant="contained"
-        onClick={() => props.onDelete().finally(props.onClose)}
+        onClick={() => props.onDelete().catch(console.error).finally(props.onClose)}
       >
         Delete
       </Button>

--- a/app/pages/authenticated/duplicates/Duplicates.tsx
+++ b/app/pages/authenticated/duplicates/Duplicates.tsx
@@ -44,7 +44,12 @@ const Duplicates = () => {
   )
 
   const onDeleteVideo = async (videoId: string) => {
-    await deleteVideo(videoId, true)
+    try {
+      await deleteVideo(videoId, true)
+    } catch (error) {
+      console.error(error)
+      return
+    }
 
     setGroups(prev =>
       prev

--- a/app/pages/authenticated/playlists/components/CreatePlaylistDialog.tsx
+++ b/app/pages/authenticated/playlists/components/CreatePlaylistDialog.tsx
@@ -38,6 +38,8 @@ const CreatePlaylistDialog: FC<CreatePlaylistDialogProps> = ({
       onPlaylistCreated(playlist)
       setName("")
       setDescription("")
+    } catch (error) {
+      console.error(error)
     } finally {
       setIsSubmitting(false)
     }

--- a/app/pages/authenticated/videos/components/VideoSitesSelector.tsx
+++ b/app/pages/authenticated/videos/components/VideoSitesSelector.tsx
@@ -25,7 +25,7 @@ const VideoSitesSelector: FC<VideoSitesSelectorProps> = props => {
   const [availableVideoSites, setAvailableVideoSites] = useState<string[]>([])
 
   useEffect(() => {
-    videoServiceSummary().then((summary) => setAvailableVideoSites(summary.sites))
+    videoServiceSummary().then((summary) => setAvailableVideoSites(summary.sites)).catch(console.error)
   }, [])
 
   return (

--- a/tests/components/CreatePlaylistDialog.test.tsx
+++ b/tests/components/CreatePlaylistDialog.test.tsx
@@ -139,4 +139,38 @@ describe("CreatePlaylistDialog", () => {
       expect(onPlaylistCreated).toHaveBeenCalled()
     })
   })
+
+  test("should remain usable when createPlaylist fails", async () => {
+    const { createPlaylist } = await import("~/services/playlist/PlaylistService")
+    vi.mocked(createPlaylist).mockRejectedValue(new Error("Failed to create playlist"))
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    render(
+      <CreatePlaylistDialog
+        isOpen={true}
+        onClose={onClose}
+        onPlaylistCreated={onPlaylistCreated}
+      />
+    )
+
+    const nameInput = screen.getByLabelText("Name")
+    fireEvent.change(nameInput, { target: { value: "Test Playlist" } })
+
+    const createButton = screen.getByRole("button", { name: "Create" })
+    fireEvent.click(createButton)
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+
+    expect(onPlaylistCreated).not.toHaveBeenCalled()
+    expect(nameInput).toHaveValue("Test Playlist")
+    expect(createButton).not.toBeDisabled()
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" })
+    fireEvent.click(cancelButton)
+    expect(onClose).toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
 })

--- a/tests/pages/Duplicates.test.tsx
+++ b/tests/pages/Duplicates.test.tsx
@@ -202,6 +202,33 @@ describe("Duplicates", () => {
     })
   })
 
+  test("should keep the video in the group when delete fails", async () => {
+    const user = userEvent.setup()
+    mockFetchDuplicateVideos.mockResolvedValue({
+      "group-1": createDuplicateGroup("group-1", ["video-1", "video-2"]),
+    })
+    mockDeleteVideo.mockRejectedValue(new Error("Failed to delete video"))
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText("Video video-1")).toBeInTheDocument()
+    })
+
+    const deleteButtons = screen.getAllByRole("button", { name: /delete/i })
+    await user.click(deleteButtons[0])
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+
+    expect(screen.getByText("Video video-1")).toBeInTheDocument()
+    expect(screen.getByText("Video video-2")).toBeInTheDocument()
+
+    consoleErrorSpy.mockRestore()
+  })
+
   test("should render links to video pages", async () => {
     mockFetchDuplicateVideos.mockResolvedValue({
       "group-1": createDuplicateGroup("group-1", ["video-1", "video-2"]),


### PR DESCRIPTION
Adds catch handlers to async event handlers and mount/interval fetches that previously produced unhandled promise rejections, covering ScheduledVideos retryAll, the ScheduledVideoDownloadCard dialog actions, Duplicates delete, CreatePlaylistDialog create, VideoScanButton (click and status poll), and the mount fetches in WorkerStatusSwitch and VideoSitesSelector. Failures are logged via console.error and existing finally/cleanup semantics are preserved, so dialogs and disabled flags reset on error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)