### PR TITLE
Pin Node 24 in deploy jobs, harden env-vars script, and fix uuid audit vulns

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -152,6 +152,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: cdk-deploy/package-lock.json
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -185,6 +192,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: cdk-deploy/package-lock.json
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -217,6 +231,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: cdk-deploy/package-lock.json
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -4817,6 +4817,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8251,14 +8260,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valibot": {
@@ -8716,15 +8728,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "engines": {
     "node": "^24.0.0"
   },
+  "overrides": {
+    "react-d3-tree": {
+      "uuid": "^11.1.1"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@react-router/dev": "^7.6.3",

--- a/scripts/env-vars.mjs
+++ b/scripts/env-vars.mjs
@@ -3,22 +3,36 @@ import { writeFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { DateTime } from "luxon"
 
-const getEnvVariables = async () => {
-  const simpleGit = SimpleGit()
+const getGitInformation = async () => {
+  try {
+    const simpleGit = SimpleGit()
 
-  const gitBranch = await simpleGit.branch()
-  const gitCommitHash = await simpleGit.revparse(["--short", "HEAD"])
+    const gitBranch = await simpleGit.branch()
+    const gitCommitHash = await simpleGit.revparse(["--short", "HEAD"])
+
+    return { branch: gitBranch.current, commit: gitCommitHash }
+  } catch (error) {
+    console.warn(
+      `Unable to determine git branch/commit (${error.message ?? error}). Falling back to placeholder values.`
+    )
+
+    return { branch: "unknown", commit: "unknown" }
+  }
+}
+
+const getEnvVariables = async () => {
+  const { branch, commit } = await getGitInformation()
 
   const timestamp = DateTime.now().toISO()
 
   return [
     {
       name: "VITE_GIT_BRANCH",
-      value: gitBranch.current,
+      value: branch,
     },
     {
       name: "VITE_GIT_COMMIT",
-      value: gitCommitHash,
+      value: commit,
     },
     {
       name: "VITE_BUILD_TIMESTAMP",
@@ -39,4 +53,7 @@ const main = async () => {
   await writeToEnvFile(envVariables)
 }
 
-main()
+main().catch(error => {
+  console.error(`Failed to generate .env file: ${error.message ?? error}`)
+  process.exitCode = 1
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,6 +5,7 @@ import { afterEach, vi } from "vitest"
 // Cleanup after each test
 afterEach(() => {
   cleanup()
+  intersectionObserverCallbacks.length = 0
 })
 
 // Mock window.matchMedia


### PR DESCRIPTION
Adds actions/setup-node (Node 24, npm cache keyed on cdk-deploy/package-lock.json) to the three CDK deploy jobs, which previously ran npm ci with the runner's unpinned system Node. Also makes scripts/env-vars.mjs fall back to placeholder values with a clear message instead of crashing outside a git checkout, clears the 3 moderate npm audit vulnerabilities by overriding react-d3-tree's uuid to ^11.1.1, and adds a global afterEach in tests/setup.ts that resets intersectionObserverCallbacks between tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)