### PR TITLE
Fix edge cases in models, Either, and formatters

### DIFF
--- a/app/models/Codec.ts
+++ b/app/models/Codec.ts
@@ -1,4 +1,4 @@
-import { Either, Right } from "~/types/Either"
+import { Either, Left, Right } from "~/types/Either"
 
 export type Codec<A, B> = Encoder<A, B> & Decoder<B, A>
 
@@ -15,10 +15,10 @@ export function codec<A, B>(encoder: Encoder<A, B>, decoder: Decoder<B, A>): Cod
 
 export function identityCodec<A>(): Codec<A, A> {
   return {
-    decode<A>(value: A): Either<Error, A> {
+    decode(value: A): Either<Error, A> {
       return Right.of(value)
     },
-    encode<A>(value: A): A {
+    encode(value: A): A {
       return value
     },
   }
@@ -38,7 +38,7 @@ export function encodeMap<A, B, C>(encoder: Encoder<A, B>, f: (value: B) => C): 
 
 export function simpleStringEncoder<A>(): Encoder<A, string> {
   return {
-    encode<A>(value: A): string {
+    encode(value: A): string {
       return `${value}`
     },
   }
@@ -58,6 +58,10 @@ export function decodeMap<A, B, C>(decoder: Decoder<A, B>, f: (value: B) => C): 
 
 export const stringToNumberDecoder: Decoder<string, number> = {
   decode(value: string): Either<Error, number> {
-    return Either.fromTry(() => parseInt(value, 10))
+    const parsed = parseInt(value, 10)
+
+    return Number.isNaN(parsed)
+      ? Left.of(new Error(`Unable to parse "${value}" as a number`))
+      : Right.of(parsed)
   },
 }

--- a/app/models/DownloadableScheduledVideo.ts
+++ b/app/models/DownloadableScheduledVideo.ts
@@ -1,4 +1,4 @@
-import {ScheduledVideoDownload} from "~/models/ScheduledVideoDownload"
+import type {ScheduledVideoDownload} from "~/models/ScheduledVideoDownload"
 import {z} from "zod/v4"
 import {ZodDateTime, ZodOptional} from "~/types/Zod"
 
@@ -11,6 +11,4 @@ export const Downloadable = z.object({
 
 export type Downloadable = z.infer<typeof Downloadable>
 
-export const DownloadableScheduledVideo = Downloadable.and(ScheduledVideoDownload)
-
-export type DownloadableScheduledVideo = z.infer<typeof DownloadableScheduledVideo>
+export type DownloadableScheduledVideo = Downloadable & ScheduledVideoDownload

--- a/app/models/ScheduledVideoDownload.ts
+++ b/app/models/ScheduledVideoDownload.ts
@@ -8,7 +8,7 @@ const ErrorInformation = z.object({
   details: z.string(),
 }).transform(value => ({
   message: value.message,
-  stackTrace: value.details.split("\\\n")
+  stackTrace: value.details.split(/\\?\r?\n/)
 }))
 
 export const ScheduledVideoDownload = z.object({

--- a/app/models/VideoServiceSummary.ts
+++ b/app/models/VideoServiceSummary.ts
@@ -1,8 +1,5 @@
 import { z } from "zod/v4"
-import { Duration } from "luxon"
 import { ZodDuration } from "~/types/Zod"
-
-Duration.fromObject({})
 
 export const VideoServiceSummary = z.object({
   videoCount: z.number(),

--- a/app/types/Either.ts
+++ b/app/types/Either.ts
@@ -13,7 +13,7 @@ export abstract class Either<L, R> {
     try {
       return Right.of(fn())
     } catch (e) {
-      return Left.of(e as Error)
+      return Left.of(e instanceof Error ? e : new Error(String(e)))
     }
   }
 }

--- a/app/utils/Formatter.ts
+++ b/app/utils/Formatter.ts
@@ -30,7 +30,7 @@ const GIGA_BYTE: ByteSize = {
 
 export const humanReadableSize = (size: number, alwaysShowDecimals = false, separator: string = ""): string => {
   const byteSize = Option.fromNullable(
-    [GIGA_BYTE, MEGA_BYTE, KILO_BYTE].find((byteSize) => byteSize.floor < size)
+    [GIGA_BYTE, MEGA_BYTE, KILO_BYTE].find((byteSize) => byteSize.floor <= size)
   ).getOrElse(() => BYTE)
 
   return `${(size / byteSize.floor).toFixed(byteSize.unit === GIGA_BYTE.unit || alwaysShowDecimals ? 2 : 0)}${separator}${
@@ -43,11 +43,12 @@ export const humanReadableDuration = (duration: Duration): string => {
   const rescaledDuration = duration.rescale()
   const durationUnits = ["hour", "minute", "second"] as DurationUnit[]
 
-  return durationUnits
+  const parts = durationUnits
     .map<[number, DurationUnit]>(unit => [rescaledDuration.get(unit), unit])
     .filter(([value]) => value > 0)
     .map(([value, unit]) => `${value} ${unit}${value > 1 ? "s" : ""}`)
-    .join(" ")
+
+  return parts.length === 0 ? "0 seconds" : parts.join(" ")
 }
 
 export const shortHumanReadableDuration = (duration: Duration): string => {

--- a/tests/components/DownloadInformation.test.tsx
+++ b/tests/components/DownloadInformation.test.tsx
@@ -40,8 +40,8 @@ describe("DownloadInformation", () => {
 
     render(<DownloadInformation downloadableScheduledVideo={video} />)
 
-    // The humanReadableSize function uses kB format and outputs in separate elements
-    expect(screen.getByText(/1000\.00 kB/)).toBeInTheDocument()
+    // 1,000,000 B/s is exactly the MB boundary
+    expect(screen.getByText(/1\.00 MB/)).toBeInTheDocument()
     expect(screen.getByText(/\/s/)).toBeInTheDocument()
   })
 
@@ -83,7 +83,8 @@ describe("DownloadInformation", () => {
 
     render(<DownloadInformation downloadableScheduledVideo={video} />)
 
-    expect(screen.getByText(/1000\.00 B/)).toBeInTheDocument()
+    // 1000 B/s is exactly the kB boundary
+    expect(screen.getByText(/1\.00 kB/)).toBeInTheDocument()
     expect(screen.getByText(/\/s/)).toBeInTheDocument()
   })
 

--- a/tests/models/Codec.test.ts
+++ b/tests/models/Codec.test.ts
@@ -139,6 +139,19 @@ describe("stringToNumberDecoder", () => {
     expect(result).toBeInstanceOf(Right)
     expect((result as Right<Error, number>).value).toBe(3)
   })
+
+  test("should return Left for non-numeric strings", () => {
+    const result = stringToNumberDecoder.decode("not a number")
+    expect(result).toBeInstanceOf(Left)
+    expect((result as Left<Error, number>).value).toBeInstanceOf(Error)
+    expect((result as Left<Error, number>).value.message).toContain("not a number")
+  })
+
+  test("should return Left for empty strings", () => {
+    const result = stringToNumberDecoder.decode("")
+    expect(result).toBeInstanceOf(Left)
+    expect((result as Left<Error, number>).value).toBeInstanceOf(Error)
+  })
 })
 
 describe("encodeMap", () => {

--- a/tests/models/DownloadableScheduledVideo.test.ts
+++ b/tests/models/DownloadableScheduledVideo.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest"
+import type { DownloadableScheduledVideo } from "~/models/DownloadableScheduledVideo"
 import { Downloadable } from "~/models/DownloadableScheduledVideo"
+import { ScheduledVideoDownload } from "~/models/ScheduledVideoDownload"
 import { DateTime } from "luxon"
 
 describe("Downloadable", () => {
@@ -74,5 +76,47 @@ describe("Downloadable", () => {
     }
 
     expect(() => Downloadable.parse(data)).toThrow()
+  })
+})
+
+describe("DownloadableScheduledVideo", () => {
+  test("should be the intersection of Downloadable and ScheduledVideoDownload", () => {
+    const downloadable = Downloadable.parse({
+      downloadedBytes: 1024000,
+      lastUpdatedAt: "2023-10-15T10:30:00Z",
+      downloadHistory: [100, 200, 300],
+    })
+
+    const scheduledVideoDownload = ScheduledVideoDownload.parse({
+      lastUpdatedAt: "2023-10-15T10:30:00Z",
+      scheduledAt: "2023-10-15T10:00:00Z",
+      videoMetadata: {
+        url: "https://example.com/video",
+        id: "video-123",
+        videoSite: "youtube",
+        title: "Test Video",
+        duration: { length: 300, unit: "seconds" },
+        size: 1024000,
+        thumbnail: {
+          id: "thumb-123",
+          createdAt: "2023-10-15T09:00:00Z",
+          path: "/path/to/thumb",
+          mediaType: "image/jpeg",
+          size: 1024,
+        },
+      },
+      status: "Active",
+      downloadedBytes: 1024000,
+    })
+
+    const downloadableScheduledVideo: DownloadableScheduledVideo = {
+      ...scheduledVideoDownload,
+      ...downloadable,
+    }
+
+    expect(downloadableScheduledVideo.downloadHistory).toEqual([100, 200, 300])
+    expect(downloadableScheduledVideo.videoMetadata.id).toBe("video-123")
+    expect(downloadableScheduledVideo.lastUpdatedAt).toBeInstanceOf(DateTime)
+    expect(downloadableScheduledVideo.scheduledAt).toBeInstanceOf(DateTime)
   })
 })

--- a/tests/models/Models.test.ts
+++ b/tests/models/Models.test.ts
@@ -4,6 +4,8 @@ import { AuthenticationToken } from "~/models/AuthenticationToken"
 import { User } from "~/models/User"
 import { ApplicationConfiguration, Theme } from "~/models/ApplicationConfiguration"
 import { FileResource, FileResourceType } from "~/models/FileResource"
+import { VideoServiceSummary } from "~/models/VideoServiceSummary"
+import { Duration } from "luxon"
 
 describe("AuthenticationToken", () => {
   const validToken = {
@@ -228,6 +230,35 @@ describe("FileResource", () => {
       const invalid = { ...validFileResource, createdAt: "not a date" }
       expect(() => VideoFileResource.parse(invalid)).toThrow()
     })
+  })
+})
+
+describe("VideoServiceSummary", () => {
+  const validSummary = {
+    videoCount: 42,
+    totalSize: 1024000000,
+    totalDuration: { length: 3600, unit: "seconds" },
+    sites: ["youtube", "vimeo"],
+  }
+
+  test("should parse valid video service summary", () => {
+    const result = VideoServiceSummary.parse(validSummary)
+
+    expect(result.videoCount).toBe(42)
+    expect(result.totalSize).toBe(1024000000)
+    expect(result.totalDuration).toBeInstanceOf(Duration)
+    expect(result.totalDuration.as("seconds")).toBe(3600)
+    expect(result.sites).toEqual(["youtube", "vimeo"])
+  })
+
+  test("should reject missing videoCount", () => {
+    const invalid = { ...validSummary, videoCount: undefined }
+    expect(() => VideoServiceSummary.parse(invalid)).toThrow()
+  })
+
+  test("should reject non-array sites", () => {
+    const invalid = { ...validSummary, sites: "youtube" }
+    expect(() => VideoServiceSummary.parse(invalid)).toThrow()
   })
 })
 

--- a/tests/models/ScheduledVideoDownload.test.ts
+++ b/tests/models/ScheduledVideoDownload.test.ts
@@ -73,6 +73,51 @@ describe("ScheduledVideoDownload", () => {
     expect(result.errorInfo?.message).toBe("Download failed")
   })
 
+  test("should split stack trace on backslash-escaped newlines", () => {
+    const data = {
+      ...createValidData(),
+      status: "Error",
+      errorInfo: {
+        message: "Download failed",
+        details: "Connection timeout\\\nRetry failed\\\nGiving up",
+      },
+    }
+
+    const result = ScheduledVideoDownload.parse(data)
+
+    expect(result.errorInfo?.stackTrace).toEqual(["Connection timeout", "Retry failed", "Giving up"])
+  })
+
+  test("should split stack trace on plain newlines", () => {
+    const data = {
+      ...createValidData(),
+      status: "Error",
+      errorInfo: {
+        message: "Download failed",
+        details: "Connection timeout\nRetry failed\nGiving up",
+      },
+    }
+
+    const result = ScheduledVideoDownload.parse(data)
+
+    expect(result.errorInfo?.stackTrace).toEqual(["Connection timeout", "Retry failed", "Giving up"])
+  })
+
+  test("should split stack trace on CRLF newlines", () => {
+    const data = {
+      ...createValidData(),
+      status: "Error",
+      errorInfo: {
+        message: "Download failed",
+        details: "Connection timeout\r\nRetry failed",
+      },
+    }
+
+    const result = ScheduledVideoDownload.parse(data)
+
+    expect(result.errorInfo?.stackTrace).toEqual(["Connection timeout", "Retry failed"])
+  })
+
   test("should handle all scheduling statuses", () => {
     const statuses = ["Queued", "Completed", "Downloaded", "WorkersPaused", "Error", "Active", "Stale", "Acquired", "Paused", "Deleted"]
 

--- a/tests/types/Either.test.ts
+++ b/tests/types/Either.test.ts
@@ -19,6 +19,26 @@ describe("Either", () => {
       expect((result as Left<Error, number>).value).toBe(error)
     })
 
+    test("should wrap thrown non-Error values in an Error", () => {
+      const result = Either.fromTry<number>(() => {
+        throw "plain string failure"
+      })
+      expect(result).toBeInstanceOf(Left)
+      const error = (result as Left<Error, number>).value
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toBe("plain string failure")
+    })
+
+    test("should wrap thrown numbers in an Error", () => {
+      const result = Either.fromTry<number>(() => {
+        throw 404
+      })
+      expect(result).toBeInstanceOf(Left)
+      const error = (result as Left<Error, number>).value
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toBe("404")
+    })
+
     test("should handle JSON parsing", () => {
       const validJson = Either.fromTry(() => JSON.parse('{"a": 1}'))
       expect(validJson).toBeInstanceOf(Right)

--- a/tests/utils/Formatter.test.ts
+++ b/tests/utils/Formatter.test.ts
@@ -19,9 +19,9 @@ describe("humanReadableSize", () => {
     })
   })
 
-  describe("kilobytes (> 1000)", () => {
+  describe("kilobytes (>= 1000)", () => {
     test("should format kilobyte values", () => {
-      // Note: the function uses < (not <=), so 1000 stays as bytes
+      expect(humanReadableSize(1000)).toBe("1kB")
       expect(humanReadableSize(1001)).toBe("1kB")
       expect(humanReadableSize(1500)).toBe("2kB")
       expect(humanReadableSize(10000)).toBe("10kB")
@@ -29,9 +29,9 @@ describe("humanReadableSize", () => {
     })
   })
 
-  describe("megabytes (> 1,000,000)", () => {
+  describe("megabytes (>= 1,000,000)", () => {
     test("should format megabyte values", () => {
-      // Note: the function uses < (not <=), so exact boundary stays in previous unit
+      expect(humanReadableSize(1000000)).toBe("1MB")
       expect(humanReadableSize(1000001)).toBe("1MB")
       expect(humanReadableSize(1500000)).toBe("2MB")
       expect(humanReadableSize(10000000)).toBe("10MB")
@@ -39,9 +39,9 @@ describe("humanReadableSize", () => {
     })
   })
 
-  describe("gigabytes (> 1,000,000,000)", () => {
+  describe("gigabytes (>= 1,000,000,000)", () => {
     test("should format gigabyte values with decimals", () => {
-      // Note: the function uses < (not <=), so exact boundary stays in previous unit
+      expect(humanReadableSize(1000000000)).toBe("1.00GB")
       expect(humanReadableSize(1000000001)).toBe("1.00GB")
       expect(humanReadableSize(1500000000)).toBe("1.50GB")
       expect(humanReadableSize(2500000000)).toBe("2.50GB")
@@ -132,9 +132,13 @@ describe("humanReadableDuration", () => {
     expect(humanReadableDuration(duration)).toBe("1 hour 1 minute 1 second")
   })
 
-  test("should return empty string for zero duration", () => {
+  test("should return '0 seconds' for zero duration", () => {
     const duration = Duration.fromObject({ seconds: 0 })
-    expect(humanReadableDuration(duration)).toBe("")
+    expect(humanReadableDuration(duration)).toBe("0 seconds")
+  })
+
+  test("should return '0 seconds' for zero-millisecond duration", () => {
+    expect(humanReadableDuration(Duration.fromMillis(0))).toBe("0 seconds")
   })
 })
 


### PR DESCRIPTION
Fixes a set of small correctness bugs: an unmergeable Zod intersection in DownloadableScheduledVideo (now a plain type intersection), a NaN-swallowing stringToNumberDecoder, shadowed generics in identityCodec/simpleStringEncoder, stack-trace splitting that only handled backslash-escaped newlines, Either.fromTry mistyping thrown non-Errors, byte-size unit boundaries off by one, empty output for zero durations, and a dead Duration.fromObject({}) statement. Tests added or updated for each fixed edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)