### PR TITLE
Add catch-all 404 route and restyle root ErrorBoundary

### DIFF
--- a/app/index.scss
+++ b/app/index.scss
@@ -101,6 +101,49 @@ body {
   }
 }
 
+// Error boundary styles
+.error-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1em;
+  min-height: 70vh;
+  text-align: center;
+  padding: 1em;
+}
+
+.error-title {
+  font-size: 3em;
+  font-weight: 700;
+  margin: 0;
+  color: #d80027;
+}
+
+.error-details {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.error-home-link {
+  display: inline-block;
+  padding: 0.5em 1.5em;
+  border-radius: 0.25em;
+  background-color: #d80027;
+  color: #fff;
+  font-weight: 600;
+}
+
+.error-stack {
+  width: 100%;
+  max-width: 60em;
+  padding: 1em;
+  overflow-x: auto;
+  text-align: left;
+  background-color: rgba(128, 128, 128, 0.15);
+  border-radius: 0.5em;
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);

--- a/app/pages/not-found/NotFoundPage.module.scss
+++ b/app/pages/not-found/NotFoundPage.module.scss
@@ -1,0 +1,25 @@
+.notFoundPage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1em;
+  min-height: 70vh;
+  text-align: center;
+}
+
+.statusCode {
+  font-size: 5em;
+  font-weight: 700;
+  margin: 0;
+  color: #d80027;
+}
+
+.title {
+  margin: 0;
+}
+
+.description {
+  opacity: 0.7;
+  max-width: 30em;
+}

--- a/app/pages/not-found/NotFoundPage.tsx
+++ b/app/pages/not-found/NotFoundPage.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { Link } from "react-router"
+import { Button, Typography } from "@mui/material"
+import Helmet from "~/components/helmet/Helmet"
+
+import styles from "./NotFoundPage.module.scss"
+
+const NotFoundPage = () => (
+  <main className={styles.notFoundPage}>
+    <Helmet title="Page Not Found" />
+    <Typography variant="h1" className={styles.statusCode}>
+      404
+    </Typography>
+    <Typography variant="h5" component="h2" className={styles.title}>
+      Page not found
+    </Typography>
+    <Typography className={styles.description}>
+      The page you are looking for does not exist or may have been moved.
+    </Typography>
+    <Button variant="contained" color="primary" component={Link} to="/">
+      Back to Home
+    </Button>
+  </main>
+)
+
+export default NotFoundPage

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -93,11 +93,12 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   captureException(error)
 
   return (
-    <main className="pt-16 p-4 container mx-auto">
-      <h1>{message}</h1>
-      <p>{details}</p>
+    <main className="error-screen">
+      <h1 className="error-title">{message}</h1>
+      <p className="error-details">{details}</p>
+      <a className="error-home-link" href="/">Back to Home</a>
       {stack && (
-        <pre className="w-full p-4 overflow-x-auto">
+        <pre className="error-stack">
           <code>{stack}</code>
         </pre>
       )}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -16,6 +16,7 @@ export default [
   layout("pages/unauthenticated/UnauthenticatedLayout.tsx", [
     route("/sign-in", "pages/unauthenticated/login/LoginPage.tsx"),
     route("/sign-up", "pages/unauthenticated/signup/SignupPage.tsx")
-  ])
+  ]),
+  route("*", "pages/not-found/NotFoundPage.tsx")
 ] satisfies RouteConfig
 

--- a/tests/pages/NotFoundPage.test.tsx
+++ b/tests/pages/NotFoundPage.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest"
+import { render, screen } from "@testing-library/react"
+import NotFoundPage from "~/pages/not-found/NotFoundPage"
+import { createMemoryRouter, RouterProvider } from "react-router"
+import React from "react"
+
+describe("NotFoundPage", () => {
+  const renderPage = () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: "*",
+          element: <NotFoundPage />,
+        },
+      ],
+      { initialEntries: ["/some/unknown/path"] }
+    )
+
+    return render(<RouterProvider router={router} />)
+  }
+
+  test("should render 404 message", () => {
+    renderPage()
+
+    expect(screen.getByText("404")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Page not found" })).toBeInTheDocument()
+    expect(screen.getByText(/does not exist or may have been moved/)).toBeInTheDocument()
+  })
+
+  test("should render link back to home", () => {
+    renderPage()
+
+    const link = screen.getByRole("link", { name: "Back to Home" })
+
+    expect(link).toHaveAttribute("href", "/")
+  })
+
+  test("should set document title", () => {
+    renderPage()
+
+    expect(document.title).toBe("Page Not Found")
+  })
+})

--- a/tests/root.test.tsx
+++ b/tests/root.test.tsx
@@ -83,6 +83,14 @@ describe("root", () => {
       expect(screen.getByText("The requested page could not be found.")).toBeInTheDocument()
     })
 
+    test("should render a link back to home", () => {
+      mockIsRouteErrorResponse.mockReturnValue(false)
+
+      render(<ErrorBoundary error={new Error("Test error")} params={defaultParams} />)
+
+      expect(screen.getByRole("link", { name: "Back to Home" })).toHaveAttribute("href", "/")
+    })
+
     test("should render error status for other route errors", () => {
       const routeError = { status: 500, statusText: "Internal Server Error" }
       mockIsRouteErrorResponse.mockReturnValue(true)


### PR DESCRIPTION
Adds a standalone catch-all route rendering a styled NotFoundPage (SCSS module + MUI) with a link back to home, so typo'd URLs no longer fall through to the root ErrorBoundary or trigger auth redirects. Also replaces the ErrorBoundary's Tailwind classes (Tailwind isn't in this project) with project CSS and adds a home link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)