### PR TITLE
Improve accessibility of links, buttons, and EditableLabel

### DIFF
--- a/app/components/editable-label/EditableLabel.module.css
+++ b/app/components/editable-label/EditableLabel.module.css
@@ -1,2 +1,8 @@
-.readModeLabel {
+.readModeLabel .editButton {
+  opacity: 0;
+}
+
+.readModeLabel:hover .editButton,
+.readModeLabel:focus-within .editButton {
+  opacity: 1;
 }

--- a/app/components/editable-label/EditableLabel.tsx
+++ b/app/components/editable-label/EditableLabel.tsx
@@ -2,20 +2,12 @@ import React, { useState } from "react"
 import styles from "./EditableLabel.module.css"
 import { TextField } from "@mui/material"
 
-const ReadModeLabel = ({ textValue, enabledEditMode }: { textValue: string; enabledEditMode: () => void }) => {
-  const [showEdit, setShowEdit] = useState(false)
-
-  return (
-    <div
-      className={styles.readModeLabel}
-      onMouseEnter={() => setShowEdit(true)}
-      onMouseLeave={() => setShowEdit(false)}
-    >
-      {textValue}
-      {showEdit && <button onClick={enabledEditMode}>Edit</button>}
-    </div>
-  )
-}
+const ReadModeLabel = ({ textValue, enabledEditMode }: { textValue: string; enabledEditMode: () => void }) => (
+  <div className={styles.readModeLabel}>
+    {textValue}
+    <button className={styles.editButton} onClick={enabledEditMode}>Edit</button>
+  </div>
+)
 
 const EditableTextField = ({
   textValue,
@@ -36,21 +28,26 @@ const EditableTextField = ({
 )
 
 const EditableLabel = ({ textValue, onUpdateText }: { textValue: string; onUpdateText: (text: string) => Promise<void> }) => {
-  const [text, setText] = useState(textValue)
+  const [draftText, setDraftText] = useState<string>("")
   const [editMode, setEditMode] = useState(false)
 
-  const onCancel = () => {
-    setText(textValue)
-    setEditMode(false)
+  const enableEditMode = () => {
+    setDraftText(textValue)
+    setEditMode(true)
   }
 
-  const onSaveClick = (updatedText: string) => onUpdateText(updatedText).then(() => setEditMode(false))
+  const onCancel = () => setEditMode(false)
+
+  const onSaveClick = (updatedText: string) =>
+    onUpdateText(updatedText)
+      .then(() => setEditMode(false))
+      .catch((error) => console.error("Failed to update text", error))
 
   return (
     <>
-      {!editMode && <ReadModeLabel textValue={text} enabledEditMode={() => setEditMode(true)} />}
+      {!editMode && <ReadModeLabel textValue={textValue} enabledEditMode={enableEditMode} />}
       {editMode && (
-        <EditableTextField textValue={text} onTextChange={setText} onCancel={onCancel} onSaveClick={onSaveClick} />
+        <EditableTextField textValue={draftText} onTextChange={setDraftText} onCancel={onCancel} onSaveClick={onSaveClick} />
       )}
     </>
   )

--- a/app/components/video/video-metadata-card/VideoMetadataCard.tsx
+++ b/app/components/video/video-metadata-card/VideoMetadataCard.tsx
@@ -110,7 +110,7 @@ const VideoMetadataCard: FC<VideoMetadataCardProps> = props => {
         { props.children }
         {
           props.enableSourceLink &&
-          <a href={props.videoMetadata.url} target="_blank" className={styles.videoSiteUrl}>
+          <a href={props.videoMetadata.url} target="_blank" rel="noopener noreferrer" className={styles.videoSiteUrl}>
             <VideoSiteCard videoSite={props.videoMetadata.videoSite}/>
           </a>
         }

--- a/app/pages/authenticated/downloading/scheduled-video-download-card/ScheduledVideoDownloadCard.module.scss
+++ b/app/pages/authenticated/downloading/scheduled-video-download-card/ScheduledVideoDownloadCard.module.scss
@@ -39,6 +39,11 @@
     position: relative;
 
     .errorDetails {
+      background: none;
+      border: none;
+      padding: 0;
+      font-family: inherit;
+      color: inherit;
       cursor: pointer;
       text-decoration: underline;
       font-size: 0.8em;
@@ -54,6 +59,10 @@
 }
 
 .deleteButton {
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
   position: absolute;
   z-index: 1;
   right: 0.4em;

--- a/app/pages/authenticated/downloading/scheduled-video-download-card/ScheduledVideoDownloadCard.tsx
+++ b/app/pages/authenticated/downloading/scheduled-video-download-card/ScheduledVideoDownloadCard.tsx
@@ -36,12 +36,14 @@ const ScheduledVideoDownloadCard: FC<ScheduledVideoDownloadCardProps> = props =>
         classNames={styles.videoMetadata}
         enableSourceLink={true}
         disableSnapshots={true}>
-        <div
+        <button
+          type="button"
+          aria-label="Delete scheduled video"
           className={styles.deleteButton}
           onClick={() => setDialogVisibility(Some.of(ModalDialogType.Delete))}
         >
           X
-        </div>
+        </button>
       </VideoMetadataCard>
       <Timestamp timestamp={props.downloadableScheduledVideo.scheduledAt} className={styles.scheduledTimestamp}/>
       <div className={styles.downloadSection}>
@@ -156,11 +158,12 @@ const Actions: FC<ActionsProps> = props => {
       <div className={styles.statusInfo}>
         <div className={styles.status}>{status}</div>
         {status === SchedulingStatus.Error &&
-          <div
+          <button
+            type="button"
             onClick={props.onClickErrorDetails}
             className={classNames(styles.errorDetails)}>
             Error Details
-          </div>
+          </button>
         }
       </div>
     </div>

--- a/app/pages/authenticated/playlists/components/PlaylistPlayer.module.scss
+++ b/app/pages/authenticated/playlists/components/PlaylistPlayer.module.scss
@@ -88,6 +88,11 @@
 }
 
 .upNextItem {
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
   flex-shrink: 0;
   width: 12em;
   cursor: pointer;

--- a/app/pages/authenticated/playlists/components/PlaylistPlayer.tsx
+++ b/app/pages/authenticated/playlists/components/PlaylistPlayer.tsx
@@ -119,7 +119,8 @@ const PlaylistPlayer: FC<PlaylistPlayerProps> = ({
                 const actualIndex = currentIndex + 1 + idx
 
                 return (
-                  <div
+                  <button
+                    type="button"
                     key={video.videoMetadata.id}
                     className={styles.upNextItem}
                     onClick={() => onIndexChange(actualIndex)}
@@ -133,7 +134,7 @@ const PlaylistPlayer: FC<PlaylistPlayerProps> = ({
                     <div className={styles.upNextInfo}>
                       <span className={styles.upNextItemTitle}>{videoTitle}</span>
                     </div>
-                  </div>
+                  </button>
                 )
               })}
             </div>

--- a/app/pages/authenticated/videos/video-page/watch/VideoWatch.tsx
+++ b/app/pages/authenticated/videos/video-page/watch/VideoWatch.tsx
@@ -60,7 +60,7 @@ const VideoLink: FC<VideoLinkProps> = props => {
   if (props.videoMetadata.videoSite === "local") {
     return <span>{props.videoMetadata.videoSite.toUpperCase()}</span>
   } else {
-    return <a href={props.videoMetadata.url} target="_blank">{props.videoMetadata.videoSite}</a>
+    return <a href={props.videoMetadata.url} target="_blank" rel="noopener noreferrer">{props.videoMetadata.videoSite}</a>
   }
 }
 

--- a/tests/components/EditableLabel.test.tsx
+++ b/tests/components/EditableLabel.test.tsx
@@ -1,16 +1,11 @@
 import { describe, expect, test, vi } from "vitest"
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import EditableLabel from "~/components/editable-label/EditableLabel"
 
 // Helper function to enter edit mode
 async function enterEditMode(user: ReturnType<typeof userEvent.setup>) {
-  const textContainer = screen.getByText(/Title/).closest("div")!
-  await act(async () => {
-    fireEvent.mouseEnter(textContainer)
-  })
-  const editButton = await screen.findByRole("button", { name: /edit/i })
-  await user.click(editButton)
+  await user.click(screen.getByRole("button", { name: /edit/i }))
 }
 
 describe("EditableLabel", () => {
@@ -22,46 +17,23 @@ describe("EditableLabel", () => {
       expect(screen.getByText("Test Title")).toBeInTheDocument()
     })
 
-    test("should not show edit button initially", () => {
+    test("should always render the edit button so it is reachable by keyboard", () => {
       const onUpdateText = vi.fn()
       render(<EditableLabel textValue="Test Title" onUpdateText={onUpdateText} />)
 
-      expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument()
     })
 
-    test("should show edit button on hover", async () => {
+    test("should update displayed label when textValue prop changes", () => {
       const onUpdateText = vi.fn()
-      render(<EditableLabel textValue="Test Title" onUpdateText={onUpdateText} />)
+      const { rerender } = render(<EditableLabel textValue="Initial Title" onUpdateText={onUpdateText} />)
 
-      const textContainer = screen.getByText("Test Title").closest("div")!
-      await act(async () => {
-        fireEvent.mouseEnter(textContainer)
-      })
+      expect(screen.getByText("Initial Title")).toBeInTheDocument()
 
-      await waitFor(() => {
-        expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument()
-      })
-    })
+      rerender(<EditableLabel textValue="Updated Title" onUpdateText={onUpdateText} />)
 
-    test("should hide edit button when mouse leaves", async () => {
-      const onUpdateText = vi.fn()
-      render(<EditableLabel textValue="Test Title" onUpdateText={onUpdateText} />)
-
-      const textContainer = screen.getByText("Test Title").closest("div")!
-
-      await act(async () => {
-        fireEvent.mouseEnter(textContainer)
-      })
-      await waitFor(() => {
-        expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument()
-      })
-
-      await act(async () => {
-        fireEvent.mouseLeave(textContainer)
-      })
-      await waitFor(() => {
-        expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument()
-      })
+      expect(screen.getByText("Updated Title")).toBeInTheDocument()
+      expect(screen.queryByText("Initial Title")).not.toBeInTheDocument()
     })
   })
 
@@ -133,6 +105,26 @@ describe("EditableLabel", () => {
       await waitFor(() => {
         expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
       })
+    })
+
+    test("should stay in edit mode and log the error when save fails", async () => {
+      const user = userEvent.setup()
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+      const saveError = new Error("Save failed")
+      const onUpdateText = vi.fn().mockRejectedValue(saveError)
+      render(<EditableLabel textValue="Test Title" onUpdateText={onUpdateText} />)
+
+      await enterEditMode(user)
+
+      await user.click(screen.getByRole("button", { name: /save/i }))
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith("Failed to update text", saveError)
+      })
+      expect(screen.getByRole("textbox")).toBeInTheDocument()
+      expect(screen.getByRole("textbox")).toHaveValue("Test Title")
+
+      consoleErrorSpy.mockRestore()
     })
   })
 

--- a/tests/components/PlaylistPlayer.test.tsx
+++ b/tests/components/PlaylistPlayer.test.tsx
@@ -170,7 +170,7 @@ describe("PlaylistPlayer", () => {
       const onIndexChange = vi.fn()
       render(<PlaylistPlayer {...defaultProps} onIndexChange={onIndexChange} />)
 
-      await user.click(screen.getByText("Second Video"))
+      await user.click(screen.getByRole("button", { name: /Second Video/ }))
 
       expect(onIndexChange).toHaveBeenCalledWith(1)
     })

--- a/tests/components/ScheduledVideoDownloadCard.test.tsx
+++ b/tests/components/ScheduledVideoDownloadCard.test.tsx
@@ -106,13 +106,13 @@ describe("ScheduledVideoDownloadCard", () => {
   test("should render delete button", () => {
     renderWithContext()
 
-    expect(screen.getByText("X")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Delete scheduled video" })).toBeInTheDocument()
   })
 
   test("should open delete dialog when X is clicked", () => {
     renderWithContext()
 
-    fireEvent.click(screen.getByText("X"))
+    fireEvent.click(screen.getByRole("button", { name: "Delete scheduled video" }))
 
     expect(screen.getByText("Delete Scheduled Video?")).toBeInTheDocument()
   })
@@ -121,7 +121,7 @@ describe("ScheduledVideoDownloadCard", () => {
     const onDelete = vi.fn().mockResolvedValue(undefined)
     renderWithContext(createMockDownloadableScheduledVideo(), onDelete)
 
-    fireEvent.click(screen.getByText("X"))
+    fireEvent.click(screen.getByRole("button", { name: "Delete scheduled video" }))
     fireEvent.click(screen.getByRole("button", { name: "Delete" }))
 
     await waitFor(() => {
@@ -132,7 +132,7 @@ describe("ScheduledVideoDownloadCard", () => {
   test("should close delete dialog when cancel is clicked", async () => {
     renderWithContext()
 
-    fireEvent.click(screen.getByText("X"))
+    fireEvent.click(screen.getByRole("button", { name: "Delete scheduled video" }))
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
 
     await waitFor(() => {
@@ -163,16 +163,16 @@ describe("ScheduledVideoDownloadCard", () => {
     })
   })
 
-  test("should show error details link for error status", () => {
+  test("should show error details button for error status", () => {
     renderWithContext(createMockDownloadableScheduledVideo(SchedulingStatus.Error))
 
-    expect(screen.getByText("Error Details")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Error Details" })).toBeInTheDocument()
   })
 
   test("should open error dialog when error details is clicked", () => {
     renderWithContext(createMockDownloadableScheduledVideo(SchedulingStatus.Error))
 
-    fireEvent.click(screen.getByText("Error Details"))
+    fireEvent.click(screen.getByRole("button", { name: "Error Details" }))
 
     // Check that dialog opened with error message
     expect(screen.getByText("Download failed")).toBeInTheDocument()
@@ -182,7 +182,7 @@ describe("ScheduledVideoDownloadCard", () => {
   test("should render retry button in error dialog", () => {
     renderWithContext(createMockDownloadableScheduledVideo(SchedulingStatus.Error))
 
-    fireEvent.click(screen.getByText("Error Details"))
+    fireEvent.click(screen.getByRole("button", { name: "Error Details" }))
 
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument()
   })
@@ -191,7 +191,7 @@ describe("ScheduledVideoDownloadCard", () => {
     const onUpdateStatus = vi.fn().mockResolvedValue(undefined)
     renderWithContext(createMockDownloadableScheduledVideo(SchedulingStatus.Error), vi.fn(), onUpdateStatus)
 
-    fireEvent.click(screen.getByText("Error Details"))
+    fireEvent.click(screen.getByRole("button", { name: "Error Details" }))
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
 
     await waitFor(() => {


### PR DESCRIPTION
Adds rel="noopener noreferrer" to target="_blank" links, replaces click-handler divs (scheduled-download delete X and Error Details, playlist up-next items) with semantic buttons styled to match the existing look, and fixes EditableLabel to re-sync with prop changes, always render a keyboard-reachable Edit button, and stay in edit mode when a save fails. Tests updated to query the new buttons by role, with new coverage for prop-driven label updates and failed saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)