### PR TITLE
Add Branch environment and test Config / ApiConfiguration

### DIFF
--- a/app/services/ApiConfiguration.ts
+++ b/app/services/ApiConfiguration.ts
@@ -2,8 +2,11 @@ import { Environment, getEnvironment } from "~/services/Config"
 
 const API_URL_QUERY_PARAMETER = "API_URL"
 
-const API_URL_MAPPINGS: Record<Environment.Staging | Environment.Production, string> = {
+type NonLocalEnvironment = Environment.Branch | Environment.Staging | Environment.Production
+
+const API_URL_MAPPINGS: Record<NonLocalEnvironment, string> = {
   [Environment.Staging]: "api.staging.video.dev.ruchij.com",
+  [Environment.Branch]: "api.staging.video.dev.ruchij.com",
   [Environment.Production]: "api.video.home.ruchij.com"
 }
 
@@ -27,7 +30,7 @@ const inferBaseApiUrl = (): string => {
       const environment = getEnvironment()
 
       if (environment in API_URL_MAPPINGS) {
-        return `${location.protocol}//${API_URL_MAPPINGS[environment as Environment.Staging | Environment.Production]}`
+        return `${location.protocol}//${API_URL_MAPPINGS[environment as NonLocalEnvironment]}`
       } else {
         const apiUrl = `${location.protocol}//api.${location.host}`
         return apiUrl

--- a/app/services/Config.ts
+++ b/app/services/Config.ts
@@ -1,7 +1,8 @@
-import { Option } from "~/types/Option"
+import {Option} from "~/types/Option"
 
 export enum Environment {
   Development,
+  Branch,
   Staging,
   Production
 }
@@ -16,9 +17,14 @@ export const getEnvironment = (): Environment => {
     return Environment.Development
   }
 
+  const isBranch = (host: string): boolean => {
+    const branchHostRegex = /^.+\.videos\.ruchij\.com$/;
+    return branchHostRegex.test(host);
+  }
+
   const host: string = window.location.host
 
   return Option.fromNullable(Object.entries(URL_MAPPINGS).find(([_, hosts]) => hosts.includes(host)))
-    .map(([env]) => env as unknown as Environment)
-    .getOrElse(() => Environment.Development)
+    .map(([env]) => Number(env) as Environment)
+    .getOrElse(() => isBranch(host) ? Environment.Branch : Environment.Development)
 }

--- a/app/services/Sentry.ts
+++ b/app/services/Sentry.ts
@@ -1,9 +1,12 @@
 import * as Sentry from "@sentry/react"
 import { Environment, getEnvironment } from "~/services/Config"
 
+const STAGING_DSN = "https://0c16af37660ae085a000b8b8f9d79a17@o4510770741837824.ingest.us.sentry.io/4510771760791552"
+
 const DSN_MAPPINGS: Record<Environment, string> = {
   [Environment.Development]: "https://3cefa278484696cde7ff9e066525fa87@o4510770741837824.ingest.us.sentry.io/4510771763085312",
-  [Environment.Staging]: "https://0c16af37660ae085a000b8b8f9d79a17@o4510770741837824.ingest.us.sentry.io/4510771760791552",
+  [Environment.Branch]: STAGING_DSN,
+  [Environment.Staging]: STAGING_DSN,
   [Environment.Production]: "https://77f336ea08b08c576b93c76458db362f@o4510770741837824.ingest.us.sentry.io/4510771752992768"
 }
 

--- a/tests/services/ApiConfiguration.test.ts
+++ b/tests/services/ApiConfiguration.test.ts
@@ -7,6 +7,7 @@ describe("ApiConfiguration", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
     vi.resetModules()
   })
 
@@ -48,17 +49,33 @@ describe("ApiConfiguration", () => {
         history: { replaceState: vi.fn() },
       })
 
-      // Mock import.meta.env
-      vi.stubGlobal("import", {
-        meta: {
-          env: {
-            VITE_API_URL: "https://env-api.example.com",
-          },
-        },
-      })
+      vi.stubEnv("VITE_API_URL", "https://env-api.example.com")
 
       vi.resetModules()
-      // Note: This test may not fully work due to import.meta limitations in testing
+      const { apiConfiguration } = await import("~/services/ApiConfiguration")
+
+      expect(apiConfiguration.baseUrl).toBe("https://env-api.example.com")
+    })
+
+    test("should prefer the API_URL query parameter over VITE_API_URL", async () => {
+      const mockUrl = new URL("https://example.com?API_URL=https://custom-api.example.com")
+
+      vi.stubGlobal("window", {
+        location: {
+          href: mockUrl.href,
+          search: mockUrl.search,
+          protocol: mockUrl.protocol,
+          host: mockUrl.host,
+        },
+        history: { replaceState: vi.fn() },
+      })
+
+      vi.stubEnv("VITE_API_URL", "https://env-api.example.com")
+
+      vi.resetModules()
+      const { apiConfiguration } = await import("~/services/ApiConfiguration")
+
+      expect(apiConfiguration.baseUrl).toBe("https://custom-api.example.com")
     })
 
     test("should use API_URL_MAPPINGS for known hosts", async () => {
@@ -98,6 +115,25 @@ describe("ApiConfiguration", () => {
       const { apiConfiguration } = await import("~/services/ApiConfiguration")
 
       expect(apiConfiguration.baseUrl).toBe("https://api.video.home.ruchij.com")
+    })
+
+    test("should use the staging API for branch hosts", async () => {
+      const mockUrl = new URL("https://my-feature.videos.ruchij.com")
+
+      vi.stubGlobal("window", {
+        location: {
+          href: mockUrl.href,
+          search: "",
+          protocol: "https:",
+          host: "my-feature.videos.ruchij.com",
+        },
+        history: { replaceState: vi.fn() },
+      })
+
+      vi.resetModules()
+      const { apiConfiguration } = await import("~/services/ApiConfiguration")
+
+      expect(apiConfiguration.baseUrl).toBe("https://api.staging.video.dev.ruchij.com")
     })
 
     test("should fallback to api.{host} for unknown hosts", async () => {

--- a/tests/services/Config.test.ts
+++ b/tests/services/Config.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { Environment, getEnvironment } from "~/services/Config"
+
+const stubHost = (host: string): void => {
+  vi.stubGlobal("window", { location: { host } })
+}
+
+describe("Config", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe("getEnvironment", () => {
+    test("returns Development when there is no window (server-side)", () => {
+      vi.stubGlobal("window", undefined)
+
+      expect(getEnvironment()).toBe(Environment.Development)
+    })
+
+    test("returns Staging for the staging host", () => {
+      stubHost("staging.videos.ruchij.com")
+
+      expect(getEnvironment()).toBe(Environment.Staging)
+    })
+
+    test("returns Production for the production host", () => {
+      stubHost("videos.ruchij.com")
+
+      expect(getEnvironment()).toBe(Environment.Production)
+    })
+
+    test("returns Branch for a branch sub-domain of videos.ruchij.com", () => {
+      stubHost("my-feature.videos.ruchij.com")
+
+      expect(getEnvironment()).toBe(Environment.Branch)
+    })
+
+    test("returns Branch for a deeper sub-domain of videos.ruchij.com", () => {
+      stubHost("my-feature.preview.videos.ruchij.com")
+
+      expect(getEnvironment()).toBe(Environment.Branch)
+    })
+
+    test("returns Development for localhost", () => {
+      stubHost("localhost:3000")
+
+      expect(getEnvironment()).toBe(Environment.Development)
+    })
+
+    test("returns Development for an unrelated host", () => {
+      stubHost("example.com")
+
+      expect(getEnvironment()).toBe(Environment.Development)
+    })
+  })
+})


### PR DESCRIPTION
Adds an `Environment.Branch` for `*.videos.ruchij.com` preview hosts that resolves to the staging API URL and Sentry DSN, and fixes `getEnvironment` to return the numeric enum value (rather than its string key) for hosts matched in `URL_MAPPINGS`. Also adds a new `Config` test suite and fills in the previously assertion-free `VITE_API_URL` test plus a branch-host case in `ApiConfiguration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)