### PR TITLE
Fix expired-token redirect test assertion

### DIFF
--- a/tests/pages/AuthenticatedLayout.test.tsx
+++ b/tests/pages/AuthenticatedLayout.test.tsx
@@ -187,7 +187,7 @@ describe("AuthenticatedLayout", () => {
 
     await waitFor(() => {
       expect(removeAuthenticationToken).toHaveBeenCalled()
-      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=/videos")
+      expect(mockNavigate).toHaveBeenCalledWith("/sign-in?redirect=%2Fvideos")
     })
     expect(getAuthenticatedUser).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
The `AuthenticatedLayout` expired-token test still expected the unencoded `/sign-in?redirect=/videos`, but #29 changed the redirect to `encodeURIComponent(pathname + search)`. Both PRs passed alone, but together they broke main. This updates the assertion to the encoded `%2Fvideos` form — matching the sibling test and the actual (intended) behaviour — which greens the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)